### PR TITLE
Add ETF weight visualization

### DIFF
--- a/display/gui/gui_input.py
+++ b/display/gui/gui_input.py
@@ -24,6 +24,7 @@ PLOT_TYPES = (
     "Term (ATM vs T)",
     "Corr Matrix (ATM)",
     "Synthetic Surface (Smile)",
+    "ETF Weights",
 )
 
 class InputPanel(ttk.Frame):

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -148,6 +148,19 @@ class PlotManager:
             self._plot_synth_surface(ax, target, peers, asof, T_days, weight_mode)
             return
 
+        # --- ETF Weights only ---
+        elif plot_type.startswith("ETF Weights"):
+            if not peers:
+                ax.text(0.5, 0.5, "No peers", ha="center", va="center")
+                return
+            weights = self._weights_from_ui_or_matrix(target, peers, weight_mode, asof=asof, pillars=pillars)
+            if weights is None or weights.empty:
+                ax.text(0.5, 0.5, "No weights", ha="center", va="center")
+                return
+            from display.plotting.weights_plot import plot_weights
+            plot_weights(ax, weights)
+            return
+
         else:
             ax.text(0.5, 0.5, f"Unknown plot: {plot_type}", ha="center", va="center")
 

--- a/display/plotting/__init__.py
+++ b/display/plotting/__init__.py
@@ -1,5 +1,3 @@
-"""
-Plotting module for CleanIV_Correlation project.
+"""Plotting utilities for the project."""
 
-This module contains plotting utilities for term structures, smiles, and confidence bands.
-"""
+from .weights_plot import plot_weights

--- a/display/plotting/weights_plot.py
+++ b/display/plotting/weights_plot.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import pandas as pd
+import matplotlib.pyplot as plt
+from typing import Mapping, Sequence
+
+
+def plot_weights(ax: plt.Axes, weights: Mapping[str, float] | Sequence[float] | pd.Series) -> None:
+    """Render weights as a sorted bar chart.
+
+    Parameters
+    ----------
+    ax : plt.Axes
+        Matplotlib axis to draw on. It will be cleared.
+    weights : mapping or sequence or pd.Series
+        Mapping/series of label -> weight values or sequence of weights (labels
+        will be numeric indices).
+    """
+    ax.clear()
+    if weights is None:
+        ax.text(0.5, 0.5, "No weights", ha="center", va="center")
+        return
+
+    if isinstance(weights, pd.Series):
+        s = weights.astype(float)
+    elif isinstance(weights, Mapping):
+        s = pd.Series(dict(weights), dtype=float)
+    else:
+        s = pd.Series(list(weights), dtype=float)
+
+    if s.empty:
+        ax.text(0.5, 0.5, "No weights", ha="center", va="center")
+        return
+
+    s = s.sort_values(ascending=False)
+    x = range(len(s))
+    bars = ax.bar(x, s.values, color="steelblue")
+    ax.set_title("ETF Weights")
+    ax.set_ylabel("Weight")
+    ax.set_ylim(0, max(float(s.max()) * 1.1, 1.0))
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(s.index.astype(str), rotation=45, ha="right")
+
+    for idx, (bar, val) in enumerate(zip(bars, s.values)):
+        ax.text(bar.get_x() + bar.get_width() / 2, val, f"{val:.3f}",
+                ha="center", va="bottom", fontsize=8)


### PR DESCRIPTION
## Summary
- add bar chart plot function for ETF weight components
- expose ETF weights as new plot type in GUI and plot manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c91e948808333a1791a735a6df534