### PR TITLE
Add underlying correlation weights using yfinance data

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -39,7 +39,6 @@ from .syntheticETFBuilder import (
 
 from .beta_builder import (
     pca_weights,
-    ul_betas,
     iv_atm_betas,
     surface_betas,
     peer_weights_from_correlations,
@@ -189,7 +188,14 @@ def compute_peer_weights(
     tenor_days: Iterable[int] = DEFAULT_TENORS,
     mny_bins: Tuple[Tuple[float, float], ...] = DEFAULT_MNY_BINS,
 ) -> pd.Series:
-    """Compute peer weights via correlation or PCA metrics vs a target."""
+    """Compute peer weights via correlation or PCA metrics vs a target.
+
+    Parameters
+    ----------
+    weight_mode : str
+        ``"iv_atm"`` (default), ``"surface"``, ``"ul"``/``"underlying```, or
+        PCA variants such as ``"pca_atm_market"``.
+    """
     target = target.upper()
     peers = [p.upper() for p in peers]
     mode = (weight_mode or "iv_atm").lower()

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -6,11 +6,12 @@ This module contains data handling, downloading, and database utilities.
 
 # Import key functions for easier access
 from .ticker_groups import (
-    save_ticker_group, load_ticker_group, list_ticker_groups, 
+    save_ticker_group, load_ticker_group, list_ticker_groups,
     delete_ticker_group, create_default_groups
 )
 from .db_utils import get_conn, ensure_initialized
 from .historical_saver import save_for_tickers
+from .underlying_prices import update_underlying_prices
 from .interest_rates import (
     save_interest_rate, load_interest_rate, get_default_interest_rate,
     list_interest_rates, delete_interest_rate, set_default_interest_rate,
@@ -21,6 +22,7 @@ __all__ = [
     'save_ticker_group', 'load_ticker_group', 'list_ticker_groups',
     'delete_ticker_group', 'create_default_groups',
     'get_conn', 'ensure_initialized', 'save_for_tickers',
+    'update_underlying_prices',
     'save_interest_rate', 'load_interest_rate', 'get_default_interest_rate',
     'list_interest_rates', 'delete_interest_rate', 'set_default_interest_rate',
     'get_interest_rate_names', 'create_default_interest_rates'

--- a/data/db_schema.py
+++ b/data/db_schema.py
@@ -38,6 +38,13 @@ CREATE TABLE IF NOT EXISTS options_quotes (
 CREATE INDEX IF NOT EXISTS idx_quotes_ticker_date ON options_quotes(ticker, asof_date);
 CREATE INDEX IF NOT EXISTS idx_quotes_expiry ON options_quotes(expiry);
 
+CREATE TABLE IF NOT EXISTS underlying_prices (
+    asof_date  TEXT NOT NULL,
+    ticker     TEXT NOT NULL,
+    close      REAL NOT NULL,
+    PRIMARY KEY (asof_date, ticker)
+);
+
 CREATE TABLE IF NOT EXISTS ticker_groups (
     group_name     TEXT    PRIMARY KEY,
     target_ticker  TEXT    NOT NULL,

--- a/data/underlying_prices.py
+++ b/data/underlying_prices.py
@@ -1,0 +1,56 @@
+"""Utilities for fetching and storing underlying price history."""
+
+from __future__ import annotations
+
+from typing import Iterable
+import pandas as pd
+import yfinance as yf
+
+from .db_utils import get_conn, ensure_initialized
+
+
+def _fetch_history(ticker: str, period: str = "1y") -> pd.DataFrame:
+    """Download historical daily close prices for ``ticker`` from yfinance."""
+    tk = yf.Ticker(ticker)
+    try:
+        hist = tk.history(period=period)
+    except Exception:
+        return pd.DataFrame()
+    if hist.empty or "Close" not in hist.columns:
+        return pd.DataFrame()
+    df = hist.reset_index()[["Date", "Close"]].rename(
+        columns={"Date": "asof_date", "Close": "close"}
+    )
+    df["asof_date"] = pd.to_datetime(df["asof_date"]).dt.date.astype(str)
+    df["ticker"] = ticker.upper()
+    return df[["asof_date", "ticker", "close"]]
+
+
+def update_underlying_prices(tickers: Iterable[str], period: str = "1y") -> int:
+    """Fetch and upsert historical prices for ``tickers`` into the DB.
+
+    Returns the total number of rows inserted.
+    """
+    conn = get_conn()
+    ensure_initialized(conn)
+
+    total = 0
+    for t in tickers:
+        df = _fetch_history(t, period=period)
+        if df.empty:
+            continue
+        rows = [tuple(x) for x in df.itertuples(index=False, name=None)]
+        conn.executemany(
+            """
+            INSERT OR REPLACE INTO underlying_prices(asof_date, ticker, close)
+            VALUES (?, ?, ?)
+            """,
+            rows,
+        )
+        conn.commit()
+        total += len(rows)
+    return total
+
+
+__all__ = ["update_underlying_prices"]
+


### PR DESCRIPTION
## Summary
- Fetch and store ~1 year of underlying price history from yfinance
- Compute correlation-based peer weights from stored underlying returns
- Extend analysis pipeline and DB schema to support underlying weight mode

## Testing
- `python -m py_compile analysis/beta_builder.py analysis/analysis_pipeline.py data/underlying_prices.py data/__init__.py data/db_schema.py`
- `python - <<'PY'
from data.underlying_prices import update_underlying_prices
from analysis.analysis_pipeline import compute_peer_weights
update_underlying_prices(['SPY','AAPL'], period='1y')
w = compute_peer_weights(target='SPY', peers=['AAPL'], weight_mode='ul')
print('weights:', w)
PY` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb3d09b88333b313c7c6da5fc6a3