### PR TITLE
Add scatter plot correlation helper with flexible column selection

### DIFF
--- a/tests/test_scatter_corr.py
+++ b/tests/test_scatter_corr.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Ensure project root on path for module imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from display.plotting.correlation_detail_plot import scatter_corr_matrix
+
+
+def test_scatter_corr_subset_columns():
+    df = pd.DataFrame({
+        'a': [1, 2, 3, 4],
+        'b': [2, 4, 6, 8],
+        'c': [10, 11, 12, 13],
+    })
+    corr = scatter_corr_matrix(df, columns=['a', 'b'], plot=False)
+    assert list(corr.columns) == ['a', 'b']
+    assert corr.loc['a', 'b'] == 1.0


### PR DESCRIPTION
## Summary
- Provide `scatter_corr_matrix` helper to compute correlation across CSV columns and optionally draw a scatter matrix.
- Handles column down-selection safely by ignoring missing columns.
- Add unit test covering subset column correlation.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e09be2d5083338c5abd700ac47670