### PR TITLE
Centralise ATM correlation utilities and unify weight API

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -47,6 +47,7 @@ from .beta_builder import (
     cosine_similarity_weights,
 )
 from .pillars import load_atm, nearest_pillars, DEFAULT_PILLARS_DAYS
+from .correlation_utils import compute_atm_corr, corr_weights
 
 
 # =========================
@@ -249,6 +250,19 @@ def compute_peer_weights(
             tenor_days=tenor_days,
             mny_bins=mny_bins,
         )
+    if mode == "corr_atm":
+        if asof is None:
+            dates = available_dates(ticker=target, most_recent_only=True)
+            asof = dates[0] if dates else None
+        if asof is None:
+            return pd.Series(dtype=float)
+        atm_df, corr_df = compute_atm_corr(
+            get_smile_slice=get_smile_slice,
+            tickers=[target] + peers,
+            asof=asof,
+            pillars_days=pillar_days,
+        )
+        return corr_weights(corr_df, target, peers)
     return peer_weights_from_correlations(
         benchmark=target,
         peers=peers,

--- a/analysis/correlation_utils.py
+++ b/analysis/correlation_utils.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pandas as pd
+from typing import Iterable, List, Optional, Tuple
+
+from .pillars import build_atm_matrix
+
+
+def compute_atm_corr(
+    get_smile_slice,
+    tickers: Iterable[str],
+    asof: str,
+    pillars_days: Iterable[int],
+    atm_band: float = 0.05,
+    tol_days: float = 7.0,
+    min_pillars: int = 2,
+    demean_rows: bool = False,
+    corr_method: str = "pearson",
+    min_tickers_per_pillar: int = 3,
+    min_pillars_per_ticker: int = 2,
+    ridge: float = 1e-6,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Return (ATM matrix, correlation matrix) for one as-of date."""
+    atm_df, corr_df = build_atm_matrix(
+        get_smile_slice=get_smile_slice,
+        tickers=tickers,
+        asof=asof,
+        pillars_days=pillars_days,
+        atm_band=atm_band,
+        tol_days=tol_days,
+        min_pillars=min_pillars,
+        corr_method=corr_method,
+        demean_rows=demean_rows,
+    )
+    # Drop sparse pillars/tickers (ETF-style filtering)
+    if not atm_df.empty:
+        # keep pillars with at least min_tickers_per_pillar non-NaN entries
+        col_coverage = atm_df.count(axis=0)
+        good_pillars = col_coverage[col_coverage >= min_tickers_per_pillar].index
+        atm_df = atm_df[good_pillars] if len(good_pillars) >= 2 else atm_df
+        # keep tickers with at least min_pillars_per_ticker pillars
+        row_coverage = atm_df.count(axis=1)
+        good_tickers = row_coverage[row_coverage >= min_pillars_per_ticker].index
+        atm_df = atm_df.loc[good_tickers] if len(good_tickers) >= 2 else atm_df
+        # recompute correlation with ridge regularisation
+        if not atm_df.empty and atm_df.shape[0] >= 2 and atm_df.shape[1] >= 2:
+            atm_clean = atm_df.dropna()
+            if atm_clean.shape[0] >= 2 and atm_clean.shape[1] >= 2:
+                atm_std = (atm_clean - atm_clean.mean(axis=1).values.reshape(-1, 1)) / (
+                    atm_clean.std(axis=1).values.reshape(-1, 1) + 1e-8
+                )
+                corr_matrix = (atm_std @ atm_std.T) / max(atm_std.shape[1] - 1, 1)
+                corr_matrix += ridge * np.eye(corr_matrix.shape[0])
+                corr_df = pd.DataFrame(corr_matrix, index=atm_clean.index, columns=atm_clean.index)
+    return atm_df, corr_df
+
+
+def corr_weights(
+    corr_df: pd.DataFrame,
+    target: str,
+    peers: List[str],
+    clip_negative: bool = True,
+    power: float = 1.0,
+) -> pd.Series:
+    """Convert correlations with target into normalised positive weights on peers."""
+    target = target.upper()
+    peers = [p.upper() for p in peers]
+    s = corr_df.reindex(index=peers, columns=[target]).iloc[:, 0].apply(pd.to_numeric, errors="coerce")
+    if clip_negative:
+        s = s.clip(lower=0.0)
+    if power is not None and float(power) != 1.0:
+        s = s.pow(float(power))
+    total = float(s.sum())
+    if not np.isfinite(total) or total <= 0:
+        return pd.Series(1.0 / max(len(peers), 1), index=peers, dtype=float)
+    return (s / total).fillna(0.0)

--- a/analysis/pillars.py
+++ b/analysis/pillars.py
@@ -427,32 +427,6 @@ def compute_atm_by_expiry(
 
     return pd.DataFrame(rows).sort_values("T").reset_index(drop=True)
 
-# ---------------------------------------------------------------------
-# Weights from a live correlation matrix (target vs peers)
-# ---------------------------------------------------------------------
-def corr_weights_from_matrix(
-    corr_df: pd.DataFrame,
-    target: str,
-    peers: List[str],
-    clip_negative: bool = True,
-    power: float = 1.0,
-) -> pd.Series:
-    """
-    Convert correlation column (w.r.t. target) into normalized positive weights.
-    """
-    target = target.upper()
-    peers = [p.upper() for p in peers]
-    s = corr_df.reindex(index=peers, columns=[target]).iloc[:, 0].astype(float)
-    if clip_negative:
-        s = s.clip(lower=0.0)
-    if power is not None and power != 1.0:
-        s = s.pow(float(power))
-    total = float(s.sum())
-    if not np.isfinite(total) or total <= 0:
-        # fallback equal
-        return pd.Series(1.0 / max(len(peers), 1), index=peers, dtype=float)
-    return s / total
-
 # Public tiny helper: build ATM curve for GUI/plots
 def atm_curve_for_ticker_on_date(
     get_smile_slice,

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -5,8 +5,8 @@ import pandas as pd
 
 from display.plotting.correlation_detail_plot import (
     compute_and_plot_correlation,   # draws the corr heatmap
-    corr_weights_from_matrix,       # converts a column of the matrix to weights
 )
+from analysis.correlation_utils import corr_weights
 from analysis.beta_builder import pca_weights, pca_weights_from_atm_matrix
 from display.plotting.smile_plot import fit_and_plot_smile
 from display.plotting.term_plot import plot_atm_term_structure
@@ -268,7 +268,7 @@ class PlotManager:
         # 1) Use cached Corr Matrix from the Corr Matrix plot
         if isinstance(self.last_corr_df, pd.DataFrame) and not self.last_corr_df.empty:
             try:
-                w = corr_weights_from_matrix(self.last_corr_df, target, peers, clip_negative=True, power=1.0)
+                w = corr_weights(self.last_corr_df, target, peers, clip_negative=True, power=1.0)
                 if w is not None and not w.empty and np.isfinite(w.to_numpy(dtype=float)).any():
                     # Normalize and keep only peers that had a column in the matrix
                     w = w.dropna().astype(float)


### PR DESCRIPTION
## Summary
- Add `analysis.correlation_utils` with `compute_atm_corr` and `corr_weights`
- Simplify `correlation_detail_plot` to delegate correlation work to analysis layer
- Support `corr_atm` mode in `compute_peer_weights` and use shared `corr_weights` in GUI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e20c436848333b5a96a3de2023f08