### PR TITLE
Separate synthetic vs peer overlays in GUI

### DIFF
--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -20,14 +20,17 @@ from display.gui.gui_plot_manager import PlotManager
 
 
 class BrowserApp(tk.Tk):
-    def __init__(self, *, overlay: bool = True, ci_percent: float = 68.0):
+    def __init__(self, *, overlay_synth: bool = True, overlay_peers: bool = True,
+                 ci_percent: float = 68.0):
         super().__init__()
         self.title("Implied Volatility Browser")
         self.geometry("1200x820")
         self.minsize(800, 600)
 
         # Inputs
-        self.inputs = InputPanel(self, overlay=overlay, ci_percent=ci_percent)
+        self.inputs = InputPanel(self, overlay_synth=overlay_synth,
+                                 overlay_peers=overlay_peers,
+                                 ci_percent=ci_percent)
         self.inputs.bind_download(self._on_download)
         self.inputs.bind_plot(self._refresh_plot)
         self.inputs.bind_target_change(self._on_target_change)
@@ -118,17 +121,18 @@ class BrowserApp(tk.Tk):
 
     def _refresh_plot(self):
         settings = dict(
-            plot_type  = self.inputs.get_plot_type(),
-            target     = self.inputs.get_target(),
-            asof       = self.inputs.get_asof(),
-            model      = self.inputs.get_model(),
-            T_days     = self.inputs.get_T_days(),
-            ci         = self.inputs.get_ci(),
-            x_units    = self.inputs.get_x_units(),
-            weight_mode= self.inputs.get_weight_mode(),
-            overlay    = self.inputs.get_overlay(),
-            peers      = self.inputs.get_peers(),
-            pillars    = self.inputs.get_pillars(),
+            plot_type   = self.inputs.get_plot_type(),
+            target      = self.inputs.get_target(),
+            asof        = self.inputs.get_asof(),
+            model       = self.inputs.get_model(),
+            T_days      = self.inputs.get_T_days(),
+            ci          = self.inputs.get_ci(),
+            x_units     = self.inputs.get_x_units(),
+            weight_mode = self.inputs.get_weight_mode(),
+            overlay_synth = self.inputs.get_overlay_synth(),
+            overlay_peers = self.inputs.get_overlay_peers(),
+            peers       = self.inputs.get_peers(),
+            pillars     = self.inputs.get_pillars(),
             max_expiries = self.inputs.get_max_exp(),
         )
         if not settings["target"] or not settings["asof"]:
@@ -241,11 +245,14 @@ class BrowserApp(tk.Tk):
 
 def main():
     parser = argparse.ArgumentParser(description="Vol Browser")
-    parser.add_argument("--overlay", action="store_true", help="Overlay synthetic curves")
+    parser.add_argument("--overlay-synth", action="store_true", help="Overlay synthetic curves")
+    parser.add_argument("--overlay-peers", action="store_true", help="Overlay peer curves")
     parser.add_argument("--ci", type=float, default=68.0,
                         help="Confidence interval percentage (e.g. 95 for 95%)")
     args = parser.parse_args()
-    app = BrowserApp(overlay=args.overlay, ci_percent=args.ci)
+    app = BrowserApp(overlay_synth=args.overlay_synth,
+                     overlay_peers=args.overlay_peers,
+                     ci_percent=args.ci)
     app.mainloop()
 
 if __name__ == "__main__":

--- a/display/gui/gui_input.py
+++ b/display/gui/gui_input.py
@@ -50,13 +50,16 @@ class InputPanel(ttk.Frame):
     ----------
     master : tk.Widget
         Parent widget.
-    overlay : bool, optional
+    overlay_synth : bool, optional
         Initial state for the synthetic overlay checkbox.
+    overlay_peers : bool, optional
+        Initial state for the peer overlay checkbox.
     ci_percent : float, optional
         Confidence interval expressed in percentage (e.g. 68 for 68%).
     """
 
-    def __init__(self, master, *, overlay: bool = True, ci_percent: float = 68.0):
+    def __init__(self, master, *, overlay_synth: bool = True, overlay_peers: bool = True,
+                 ci_percent: float = 68.0):
         super().__init__(master)
         self.pack(side=tk.TOP, fill=tk.X, padx=8, pady=6)
         
@@ -148,20 +151,15 @@ class InputPanel(ttk.Frame):
         self.cmb_model.set(DEFAULT_MODEL)
         self.cmb_model.grid(row=0, column=5, padx=6)
 
-        ttk.Label(row2, text="Overlay").grid(row=0, column=6, sticky="w")
-        self.var_overlay = tk.BooleanVar(value=True)
-        self.chk_overlay = ttk.Checkbutton(row2, variable=self.var_overlay, onvalue=True, offvalue=False)
-        self.chk_overlay.grid(row=0, column=7, padx=6)
-
-        ttk.Label(row2, text="Target T (days)").grid(row=0, column=8, sticky="w")
+        ttk.Label(row2, text="Target T (days)").grid(row=0, column=6, sticky="w")
         self.ent_days = ttk.Entry(row2, width=6)
         self.ent_days.insert(0, "30")
-        self.ent_days.grid(row=0, column=9, padx=6)
+        self.ent_days.grid(row=0, column=7, padx=6)
 
-        ttk.Label(row2, text="CI (%)").grid(row=0, column=10, sticky="w")
+        ttk.Label(row2, text="CI (%)").grid(row=0, column=8, sticky="w")
         self.ent_ci = ttk.Entry(row2, width=6)
         self.ent_ci.insert(0, f"{ci_percent:.0f}")
-        self.ent_ci.grid(row=0, column=11, padx=6)
+        self.ent_ci.grid(row=0, column=9, padx=6)
 
         ttk.Label(row2, text="X units").grid(row=0, column=10, sticky="w")
         self.cmb_xunits = ttk.Combobox(row2, values=["years", "days"], width=8, state="readonly")
@@ -178,7 +176,7 @@ class InputPanel(ttk.Frame):
         ttk.Label(row3, text="Weight mode").grid(row=0, column=2, sticky="w")
         self.cmb_weight_mode = ttk.Combobox(row3, values=[
             "iv_atm", "ul", "surface", "surface_grid",
-            "pca_atm_market", "pca_atm_regress", 
+            "pca_atm_market", "pca_atm_regress",
             "pca_surface_market", "pca_surface_regress"
         ], width=18, state="readonly")
         self.cmb_weight_mode.set("iv_atm")
@@ -189,12 +187,16 @@ class InputPanel(ttk.Frame):
         self.ent_pillars.insert(0, "7,30,60,90,180,365")
         self.ent_pillars.grid(row=0, column=1, padx=6)
 
-        self.var_overlay = tk.BooleanVar(value=bool(overlay))
-        self.chk_overlay = ttk.Checkbutton(row3, text="Overlay synthetic & peers", variable=self.var_overlay)
-        self.chk_overlay.grid(row=0, column=4, padx=8, sticky="w")
+        self.var_overlay_synth = tk.BooleanVar(value=bool(overlay_synth))
+        self.chk_overlay_synth = ttk.Checkbutton(row3, text="Overlay synth", variable=self.var_overlay_synth)
+        self.chk_overlay_synth.grid(row=0, column=4, padx=8, sticky="w")
+
+        self.var_overlay_peers = tk.BooleanVar(value=bool(overlay_peers))
+        self.chk_overlay_peers = ttk.Checkbutton(row3, text="Overlay peers", variable=self.var_overlay_peers)
+        self.chk_overlay_peers.grid(row=0, column=5, padx=4, sticky="w")
 
         self.btn_plot = ttk.Button(row3, text="Plot")
-        self.btn_plot.grid(row=0, column=5, padx=8)
+        self.btn_plot.grid(row=0, column=6, padx=8)
 
 
     # ---------- bindings ----------
@@ -244,9 +246,16 @@ class InputPanel(ttk.Frame):
         if not txt:
             return []
         return [p.strip().upper() for p in txt.split(",") if p.strip()]
-    
+
+    def get_overlay_synth(self) -> bool:
+        return bool(self.var_overlay_synth.get())
+
+    def get_overlay_peers(self) -> bool:
+        return bool(self.var_overlay_peers.get())
+
     def get_overlay(self) -> bool:
-        return bool(self.var_overlay.get())
+        """Backward-compatible synthetic overlay getter."""
+        return self.get_overlay_synth()
 
     def get_max_exp(self) -> int:
         try:

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -88,18 +88,19 @@ class PlotManager:
 
     # ---- main entry ----
     def plot(self, ax: plt.Axes, settings: dict):
-        plot_type  = settings["plot_type"]
-        target     = settings["target"]
-        asof       = settings["asof"]
-        model      = settings["model"]
-        T_days     = settings["T_days"]
-        ci         = settings["ci"]
-        x_units    = settings["x_units"]
-        weight_mode= settings["weight_mode"]
-        overlay    = settings["overlay"]
-        peers      = settings["peers"]
-        pillars    = settings["pillars"]
-        max_expiries = settings.get("max_expiries", 6)
+        plot_type     = settings["plot_type"]
+        target        = settings["target"]
+        asof          = settings["asof"]
+        model         = settings["model"]
+        T_days        = settings["T_days"]
+        ci            = settings["ci"]
+        x_units       = settings["x_units"]
+        weight_mode   = settings["weight_mode"]
+        overlay_synth = settings.get("overlay_synth", False)
+        overlay_peers = settings.get("overlay_peers", False)
+        peers         = settings["peers"]
+        pillars       = settings["pillars"]
+        max_expiries  = settings.get("max_expiries", 6)
 
         # remember current plot type for the click handler
         self._current_plot_type = plot_type
@@ -134,29 +135,31 @@ class PlotManager:
             weights = None
             synth_curve = None
             peer_slices: dict[str, dict] = {}
-            if overlay and peers:
-                weights = self._weights_from_ui_or_matrix(
-                    target, peers, weight_mode, asof=asof,
-                    pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None,
-                )
-                synth_curve = self._corr_weighted_synth_atm_curve(
-                    asof=asof, peers=peers, weights=weights,
-                    atm_band=ATM_BAND, t_tolerance_days=10.0,
-                )
-                for p in peers:
-                    df_p = get_smile_slice(p, asof, T_target_years=None, max_expiries=max_expiries)
-                    if df_p is None or df_p.empty:
-                        continue
-                    T_p = pd.to_numeric(df_p["T"], errors="coerce").to_numpy(float)
-                    K_p = pd.to_numeric(df_p["K"], errors="coerce").to_numpy(float)
-                    sigma_p = pd.to_numeric(df_p["sigma"], errors="coerce").to_numpy(float)
-                    S_p = pd.to_numeric(df_p["S"], errors="coerce").to_numpy(float)
-                    peer_slices[p.upper()] = {
-                        "T_arr": T_p,
-                        "K_arr": K_p,
-                        "sigma_arr": sigma_p,
-                        "S_arr": S_p,
-                    }
+            if peers:
+                if overlay_synth:
+                    weights = self._weights_from_ui_or_matrix(
+                        target, peers, weight_mode, asof=asof,
+                        pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None,
+                    )
+                    synth_curve = self._corr_weighted_synth_atm_curve(
+                        asof=asof, peers=peers, weights=weights,
+                        atm_band=ATM_BAND, t_tolerance_days=10.0,
+                    )
+                if overlay_peers:
+                    for p in peers:
+                        df_p = get_smile_slice(p, asof, T_target_years=None, max_expiries=max_expiries)
+                        if df_p is None or df_p.empty:
+                            continue
+                        T_p = pd.to_numeric(df_p["T"], errors="coerce").to_numpy(float)
+                        K_p = pd.to_numeric(df_p["K"], errors="coerce").to_numpy(float)
+                        sigma_p = pd.to_numeric(df_p["sigma"], errors="coerce").to_numpy(float)
+                        S_p = pd.to_numeric(df_p["S"], errors="coerce").to_numpy(float)
+                        peer_slices[p.upper()] = {
+                            "T_arr": T_p,
+                            "K_arr": K_p,
+                            "sigma_arr": sigma_p,
+                            "S_arr": S_p,
+                        }
 
             self._smile_ctx = {
                 "ax": ax,
@@ -179,7 +182,7 @@ class PlotManager:
             df_all = get_smile_slice(target, asof, T_target_years=None, max_expiries=max_expiries)
             if df_all is None or df_all.empty:
                 ax.set_title("No data"); return
-            self._plot_term(ax, df_all, target, asof, x_units, ci, overlay, peers, weight_mode)
+            self._plot_term(ax, df_all, target, asof, x_units, ci, overlay_synth, peers, weight_mode)
             return
 
         # --- Corr Matrix: doesn't need df_all ---
@@ -288,10 +291,12 @@ class PlotManager:
 
 
 
-    def _plot_smile(self, ax, df, target, asof, model, T_days, ci, overlay, peers, weight_mode):
+    def _plot_smile(self, ax, df, target, asof, model, T_days, ci,
+                    overlay_synth, peers, weight_mode):
         """
-        Draw target smile; if overlay is ON, draw a horizontal line at the corr-matrix
-        synthetic ATM for the nearest tenor to T_days (no recomputation of correlations).
+        Draw target smile; if synthetic overlay is ON, draw a horizontal line at the
+        corr-matrix synthetic ATM for the nearest tenor to T_days (no recomputation of
+        correlations).
         """
         import numpy as np
         import pandas as pd
@@ -311,10 +316,10 @@ class PlotManager:
         title = f"{target}  {asof}  T≈{T_used:.3f}y  RMSE={info['rmse']:.4f}"
 
 
-        # inside _plot_smile(...), replace the horizontal line section with:
-        if overlay and peers:
+        if overlay_synth and peers:
             try:
-                w = self._weights_from_ui_or_matrix(target, peers, weight_mode, asof=asof, pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None)
+                w = self._weights_from_ui_or_matrix(target, peers, weight_mode, asof=asof,
+                                                   pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None)
 
                 # build target + peers surfaces, combine peers using matrix weights
                 tickers = list({target, *peers})
@@ -514,7 +519,8 @@ class PlotManager:
         self._smile_ctx["idx"] = max(self._smile_ctx["idx"] - 1, 0)
         self._render_smile_at_index()
 
-    def _plot_term(self, ax, df, target, asof, x_units, ci, overlay, peers, weight_mode):
+    def _plot_term(self, ax, df, target, asof, x_units, ci,
+                    overlay_synth, peers, weight_mode):
         """
         Plot target ATM term structure; optionally overlay corr-matrix synthetic ATM curve
         built from peers on the SAME date (using cached matrix weights when available).
@@ -546,7 +552,7 @@ class PlotManager:
         )
         title = f"{target}  {asof}  ATM Term Structure  (N={len(atm_target)})"
 
-        if overlay and peers:
+        if overlay_synth and peers:
             try:
                 w = self._weights_from_ui_or_matrix(target, peers, weight_mode, asof=asof, pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None)
                 synth_curve = self._corr_weighted_synth_atm_curve(


### PR DESCRIPTION
## Summary
- Add distinct synthetic and peer overlay checkboxes to the GUI input panel
- Pass overlay options through Browser and CLI and handle them separately
- Update PlotManager to process synthetic and peer overlays independently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3ee96eec83339748f9ca088b221e