### PR TITLE
refactor: remove redundant column renames

### DIFF
--- a/analysis/pillars.py
+++ b/analysis/pillars.py
@@ -180,8 +180,6 @@ def load_atm(conn=None) -> pd.DataFrame:
             # Rename columns to match expected interface
             if 'ttm_years' in df.columns and 'T' not in df.columns:
                 df = df.rename(columns={'ttm_years': 'T'})
-            if 'asof_date' in df.columns and 'asof_date' not in df.columns:
-                df = df.rename(columns={'asof_date': 'asof_date'})
         
         return df
     finally:

--- a/data/data_pipeline.py
+++ b/data/data_pipeline.py
@@ -45,7 +45,6 @@ def enrich_quotes(
 
     # Compute Greeks in bulk (adds: price, delta, gamma, vega, theta, rho, d1, d2)
     # Uses ticker-specific rates if available, falls back to provided r
-    df = df.rename(columns={"call_put": "call_put"})
     df = compute_all_greeks_df(df, r=r, q=q, use_ticker_rates=True)
     
     # Store the rates that were actually used in the calculation


### PR DESCRIPTION
## Summary
- drop redundant `call_put` rename in data pipeline
- remove dead `asof_date` rename in ATM options helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e422be868833394e3827b67539fc1