### PR TITLE
refactor: centralize index creation

### DIFF
--- a/analysis/syntheticETFBuilder.py
+++ b/analysis/syntheticETFBuilder.py
@@ -38,18 +38,6 @@ def build_surface_grids(
     """
     conn = get_conn()
 
-    # Ensure helpful indexes exist for common query filters
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_options_quotes_ticker ON options_quotes(ticker)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_options_quotes_asof_date ON options_quotes(asof_date)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_options_quotes_is_atm ON options_quotes(is_atm)"
-    )
-    conn.commit()
-
     cols = "asof_date, ticker, ttm_years, moneyness, iv, is_atm"
     q = f"SELECT {cols} FROM options_quotes"
     params: list = []

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -9,7 +9,7 @@ from .ticker_groups import (
     save_ticker_group, load_ticker_group, list_ticker_groups,
     delete_ticker_group, create_default_groups
 )
-from .db_utils import get_conn, ensure_initialized
+from .db_utils import get_conn, ensure_initialized, ensure_indexes
 from .historical_saver import save_for_tickers
 from .underlying_prices import update_underlying_prices
 from .interest_rates import (
@@ -21,7 +21,7 @@ from .interest_rates import (
 __all__ = [
     'save_ticker_group', 'load_ticker_group', 'list_ticker_groups',
     'delete_ticker_group', 'create_default_groups',
-    'get_conn', 'ensure_initialized', 'save_for_tickers',
+    'get_conn', 'ensure_initialized', 'ensure_indexes', 'save_for_tickers',
     'update_underlying_prices',
     'save_interest_rate', 'load_interest_rate', 'get_default_interest_rate',
     'list_interest_rates', 'delete_interest_rate', 'set_default_interest_rate',

--- a/data/db_utils.py
+++ b/data/db_utils.py
@@ -13,8 +13,23 @@ def get_conn(db_path: Optional[str] = None) -> sqlite3.Connection:
     return conn
 
 
+def ensure_indexes(conn: sqlite3.Connection) -> None:
+    """Create indexes used by common query patterns if they don't exist."""
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_options_quotes_ticker ON options_quotes(ticker)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_options_quotes_asof_date ON options_quotes(asof_date)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_options_quotes_is_atm ON options_quotes(is_atm)"
+    )
+    conn.commit()
+
+
 def ensure_initialized(conn: sqlite3.Connection) -> None:
     init_db(conn)
+    ensure_indexes(conn)
 
 
 def insert_quotes(conn: sqlite3.Connection, quotes: Iterable[dict]) -> int:


### PR DESCRIPTION
## Summary
- add `ensure_indexes` helper to set up useful DB indexes
- initialize indexes once via `ensure_initialized` instead of in `build_surface_grids`
- export `ensure_indexes` from the data package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e422d28808333a742e8e4d97ef95b