### PR TITLE
Relax pillar detection for sparse data

### DIFF
--- a/analysis/pillars.py
+++ b/analysis/pillars.py
@@ -24,7 +24,10 @@ def detect_available_pillars(
 ) -> List[int]:
     """
     Detect which pillars have sufficient data across the given tickers.
-    Returns pillars where at least min_tickers_per_pillar have data.
+
+    Returns pillars where at least ``min_tickers_per_pillar`` tickers have
+    valid data. If no pillar meets this requirement, pillars with any data are
+    returned instead to provide a best-effort result for sparse datasets.
     """
     candidate_pillars = list(candidate_pillars)
     pillar_coverage = {p: 0 for p in candidate_pillars}
@@ -41,6 +44,11 @@ def detect_available_pillars(
     
     # Return pillars with sufficient coverage
     good_pillars = [p for p, count in pillar_coverage.items() if count >= min_tickers_per_pillar]
+
+    if not good_pillars:
+        # Fallback: include pillars that have any data at all
+        good_pillars = [p for p, count in pillar_coverage.items() if count > 0]
+
     return sorted(good_pillars)
 
 def _atm_by_pillar_from_day_slice(day_df: pd.DataFrame, pillar_days: int,


### PR DESCRIPTION
## Summary
- allow pillar detection to fall back to any pillar with data when strict coverage threshold not met

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5c7a03a483339f37c0689c069da4