### PR TITLE
Prevent duplicate legend toggle handlers

### DIFF
--- a/display/plotting/anim_utils.py
+++ b/display/plotting/anim_utils.py
@@ -255,31 +255,37 @@ def add_keyboard_toggles(
 
 
 def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) -> Legend:
-    """Make legend entries clickable to toggle series with improved visual feedback."""
+    """Make legend entries clickable to toggle series with improved visual feedback.
+
+    Previously each invocation added a new ``pick_event`` handler and instruction
+    text, which accumulated in the GUI and slowed interactions considerably.  We
+    now remove any existing handler/text before registering the new ones so that
+    only a single callback remains active per axes.
+    """
 
     leg = ax.legend()
     fig = ax.figure
     handles = leg.legend_handles if hasattr(leg, "legend_handles") else leg.legendHandles
     texts = leg.get_texts()
-    
+
     # Make handles clickable
     for handle in handles:
         handle.set_picker(True)
         # Only set pickradius if the method exists
-        if hasattr(handle, 'set_pickradius'):
+        if hasattr(handle, "set_pickradius"):
             handle.set_pickradius(15)  # Increase click area
-    
-    # Also make text labels clickable  
+
+    # Also make text labels clickable
     for text in texts:
         text.set_picker(True)
-        if hasattr(text, 'set_pickradius'):
+        if hasattr(text, "set_pickradius"):
             text.set_pickradius(15)
 
     def on_pick(event):
         artist = event.artist
-        
+
         # Determine which legend entry was clicked
-        if hasattr(artist, 'get_label'):
+        if hasattr(artist, "get_label"):
             # Clicked on a handle
             label_text = artist.get_label()
         else:
@@ -289,7 +295,7 @@ def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) ->
                 label_text = texts[text_index].get_text()
             except (ValueError, IndexError):
                 return
-        
+
         # Find matching series in series_map
         # Try exact match first, then partial match
         matched_key = None
@@ -297,7 +303,7 @@ def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) ->
             if key == label_text or label_text in key or key in label_text:
                 matched_key = key
                 break
-        
+
         if not matched_key:
             # Fallback: try to match based on common words or special cases
             label_words = label_text.lower().split()
@@ -308,53 +314,76 @@ def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) ->
                     matched_key = key
                     break
                 # Special case: CI/Confidence Interval matching
-                if ('ci' in label_text.lower() or '%' in label_text) and 'confidence' in key.lower():
+                if ("ci" in label_text.lower() or "%" in label_text) and "confidence" in key.lower():
                     matched_key = key
                     break
                 # Special case: fit matching
-                if 'fit' in label_text.lower() and 'fit' in key.lower():
+                if "fit" in label_text.lower() and "fit" in key.lower():
                     matched_key = key
                     break
-        
+
         if not matched_key:
             print(f"Warning: Could not find series for legend label '{label_text}'")
             print(f"Available series: {list(series_map.keys())}")
             return
-            
+
         arts = series_map[matched_key]
         if not arts:
             return
-            
+
         # Toggle visibility
         current_visible = arts[0].get_visible()
         new_visible = not current_visible
-        
+
         for art in arts:
             art.set_visible(new_visible)
-        
+
         # Update legend visual feedback
         # Find the corresponding handle and text
         for i, handle in enumerate(handles):
-            if (hasattr(handle, 'get_label') and handle.get_label() == label_text) or \
-               (i < len(texts) and texts[i].get_text() == label_text):
+            if (hasattr(handle, "get_label") and handle.get_label() == label_text) or (
+                i < len(texts) and texts[i].get_text() == label_text
+            ):
                 # Update handle appearance
                 handle.set_alpha(1.0 if new_visible else 0.3)
-                # Update text appearance  
+                # Update text appearance
                 if i < len(texts):
                     texts[i].set_alpha(1.0 if new_visible else 0.5)
-                    texts[i].set_weight('normal' if new_visible else 'normal')
-                    texts[i].set_style('normal' if new_visible else 'italic')
+                    texts[i].set_weight("normal" if new_visible else "normal")
+                    texts[i].set_style("normal" if new_visible else "italic")
                 break
-        
+
         fig.canvas.draw_idle()
 
-    fig.canvas.mpl_connect("pick_event", on_pick)
-    
-    # Add instruction text
-    ax.text(0.02, 0.98, "Click legend entries to toggle visibility", 
-            transform=ax.transAxes, fontsize=8, alpha=0.7,
-            verticalalignment='top', bbox=dict(boxstyle="round,pad=0.3", alpha=0.1))
-    
+    # Disconnect any previous legend toggle handler for this axes
+    if hasattr(ax, "_legend_toggle_cid"):
+        fig.canvas.mpl_disconnect(ax._legend_toggle_cid)
+
+    ax._legend_toggle_cid = fig.canvas.mpl_connect("pick_event", on_pick)
+
+    # Remove previous instruction text if it exists
+    if hasattr(ax, "_legend_toggle_text"):
+        text = ax._legend_toggle_text
+        # Text may already be detached (e.g. if the axes was cleared) which
+        # leaves it without a valid remove method. Guard against this to avoid
+        # ``NotImplementedError`` bubbling up in user code.
+        if getattr(text, "figure", None) is not None or getattr(text, "axes", None) is not None:
+            try:
+                text.remove()
+            except (ValueError, NotImplementedError):
+                pass
+
+    ax._legend_toggle_text = ax.text(
+        0.02,
+        0.98,
+        "Click legend entries to toggle visibility",
+        transform=ax.transAxes,
+        fontsize=8,
+        alpha=0.7,
+        verticalalignment="top",
+        bbox=dict(boxstyle="round,pad=0.3", alpha=0.1),
+    )
+
     return leg
 
 

--- a/tests/test_anim_utils.py
+++ b/tests/test_anim_utils.py
@@ -82,3 +82,38 @@ def test_surface_and_spillover():
     set_scatter_group_visibility(scat, groups, "G", True)
     assert scat.get_sizes()[0] > 1e-5
     plt.close(fig2)
+
+
+def test_legend_toggle_single_connection():
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([0, 1], [0, 1], label="Series")
+    series = {"Series": [line]}
+
+    # Call twice to ensure previous handler is replaced
+    leg1 = add_legend_toggles(ax, series)
+    add_legend_toggles(ax, series)
+
+    handle = leg1.legend_handles[0] if hasattr(leg1, "legend_handles") else leg1.legendHandles[0]
+    event = type("E", (), {"artist": handle, "canvas": fig.canvas, "name": "pick_event"})()
+    fig.canvas.callbacks.process("pick_event", event)
+
+    # If multiple callbacks were registered, visibility would toggle twice and stay True
+    assert series["Series"][0].get_visible() is False
+    plt.close(fig)
+
+
+def test_legend_toggle_after_axes_clear():
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([0, 1], [0, 1], label="Series")
+    series = {"Series": [line]}
+
+    # Create toggles then clear the axes to simulate GUI re-use
+    add_legend_toggles(ax, series)
+    ax.cla()
+    (line2,) = ax.plot([0, 1], [1, 0], label="Series2")
+    series2 = {"Series2": [line2]}
+
+    # Should not raise even though the previous instruction text is detached
+    add_legend_toggles(ax, series2)
+    assert hasattr(ax, "_legend_toggle_text")
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- avoid accumulating legend toggle `pick_event` handlers by disconnecting previous ones
- clean up old instruction text to prevent GUI slowdown
- guard removal of legend instructions when axes are cleared
- add regression tests ensuring a single handler and handling of cleared axes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f666e42d483338515e69a9ef0d677