### PR TITLE
Add tabbed GUI runner combining model browser and spillover

### DIFF
--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -17,6 +17,7 @@ if str(ROOT) not in sys.path:
 from analysis.analysis_pipeline import available_tickers, available_dates, ingest_and_process
 from display.gui.gui_input import InputPanel
 from display.gui.gui_plot_manager import PlotManager
+from display.gui.spillover_gui import SpilloverPanel
 
 
 class BrowserApp(tk.Tk):
@@ -27,8 +28,16 @@ class BrowserApp(tk.Tk):
         self.geometry("1200x820")
         self.minsize(800, 600)
 
+        # Notebook with tabs
+        self.notebook = ttk.Notebook(self)
+        self.notebook.pack(fill=tk.BOTH, expand=True)
+
+        # ---- Model params tab ----
+        self.tab_browser = ttk.Frame(self.notebook)
+        self.notebook.add(self.tab_browser, text="Model Params")
+
         # Inputs
-        self.inputs = InputPanel(self, overlay_synth=overlay_synth,
+        self.inputs = InputPanel(self.tab_browser, overlay_synth=overlay_synth,
                                  overlay_peers=overlay_peers,
                                  ci_percent=ci_percent)
         self.inputs.bind_download(self._on_download)
@@ -36,31 +45,31 @@ class BrowserApp(tk.Tk):
         self.inputs.bind_target_change(self._on_target_change)
 
         # Expiry navigation and animation controls
-        nav = ttk.Frame(self); nav.pack(side=tk.TOP, fill=tk.X, pady=(0,4))
-        
+        nav = ttk.Frame(self.tab_browser); nav.pack(side=tk.TOP, fill=tk.X, pady=(0,4))
+
         # Expiry navigation (existing)
         self.btn_prev = ttk.Button(nav, text="Prev Expiry", command=self._prev_expiry)
         self.btn_prev.pack(side=tk.LEFT, padx=4)
         self.btn_next = ttk.Button(nav, text="Next Expiry", command=self._next_expiry)
         self.btn_next.pack(side=tk.LEFT, padx=4)
-        
+
         # Animation controls (new)
         ttk.Separator(nav, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=8)
-        
+
         self.var_animated = tk.BooleanVar(value=False)
         self.chk_animated = ttk.Checkbutton(nav, text="Animate", variable=self.var_animated,
                                            command=self._toggle_animation_mode)
         self.chk_animated.pack(side=tk.LEFT, padx=4)
-        
+
         self.btn_play_pause = ttk.Button(nav, text="Play", command=self._toggle_animation)
         self.btn_play_pause.pack(side=tk.LEFT, padx=2)
-        
+
         self.btn_stop = ttk.Button(nav, text="Stop", command=self._stop_animation)
         self.btn_stop.pack(side=tk.LEFT, padx=2)
-        
+
         ttk.Label(nav, text="Speed:").pack(side=tk.LEFT, padx=(8,2))
         self.speed_var = tk.IntVar(value=500)  # Default speed
-        self.speed_scale = ttk.Scale(nav, from_=100, to=2000, variable=self.speed_var, 
+        self.speed_scale = ttk.Scale(nav, from_=100, to=2000, variable=self.speed_var,
                                     orient=tk.HORIZONTAL, length=100,
                                     command=self._on_speed_change)
         self.speed_scale.pack(side=tk.LEFT, padx=2)
@@ -68,12 +77,16 @@ class BrowserApp(tk.Tk):
         # Canvas
         self.fig = plt.Figure(figsize=(11.2, 6.6))
         self.ax = self.fig.add_subplot(1,1,1)
-        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self.tab_browser)
         self.canvas.draw()
         self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
 
         self.plot_mgr = PlotManager()
         self.plot_mgr.attach_canvas(self.canvas)
+
+        # ---- Spillover tab ----
+        self.tab_spillover = SpilloverPanel(self.notebook)
+        self.notebook.add(self.tab_spillover, text="Spillover")
 
         # Status bar for user feedback
         self.status = ttk.Label(self, text="Ready", anchor="w")

--- a/display/gui/spillover_gui.py
+++ b/display/gui/spillover_gui.py
@@ -12,13 +12,11 @@ if str(ROOT) not in sys.path:
 from analysis.spillover.vol_spillover import run_spillover
 
 
-class SpilloverApp(tk.Tk):
-    """Simple GUI to run spillover analysis and visualise results."""
+class SpilloverPanel(ttk.Frame):
+    """Panel containing spillover analysis controls and plots."""
 
-    def __init__(self):
-        super().__init__()
-        self.title("IV Spillover Explorer")
-        self.geometry("900x700")
+    def __init__(self, master: tk.Widget):
+        super().__init__(master)
 
         ctrl = ttk.Frame(self)
         ctrl.pack(side=tk.TOP, fill=tk.X, padx=5, pady=5)
@@ -118,6 +116,17 @@ class SpilloverApp(tk.Tk):
         self.ax.axhline(0, color="black", linewidth=0.5)
         self.ax.legend()
         self.canvas.draw()
+
+
+class SpilloverApp(tk.Tk):
+    """Standalone application wrapper for :class:`SpilloverPanel`."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("IV Spillover Explorer")
+        self.geometry("900x700")
+        panel = SpilloverPanel(self)
+        panel.pack(fill=tk.BOTH, expand=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add reusable `SpilloverPanel` for embedding spillover analysis in other GUIs
- Update `BrowserApp` to host a Notebook with model params and spillover tabs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f6c9862e883339506a31539afa38a