### PR TITLE
Handle duplicate DataFrame columns and robust legend text removal

### DIFF
--- a/data/historical_saver.py
+++ b/data/historical_saver.py
@@ -25,6 +25,15 @@ def save_for_tickers(
         if enriched is None or enriched.empty:
             print(f"No enriched rows for {t}")
             continue
+
+        # ``pandas.DataFrame.to_dict`` silently drops duplicate columns which
+        # can happen if the enrichment pipeline produces overlapping keys.  The
+        # emitted warning is noisy and, more importantly, the resulting records
+        # may not contain the intended values.  Proactively drop duplicated
+        # columns so the database always receives a clean mapping.
+        if enriched.columns.duplicated().any():
+            enriched = enriched.loc[:, ~enriched.columns.duplicated()].copy()
+
         total += insert_quotes(conn, enriched.to_dict(orient="records"))
         print(f"Inserted {t}: {len(enriched)} rows")
     return total

--- a/display/plotting/anim_utils.py
+++ b/display/plotting/anim_utils.py
@@ -368,7 +368,17 @@ def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) ->
         # Text may already be detached (e.g. if the axes was cleared) which
         # leaves it without a valid remove method. Guard against this to avoid
         # ``NotImplementedError`` bubbling up in user code.
-        if getattr(text, "figure", None) is not None or getattr(text, "axes", None) is not None:
+        #
+        # A previously created text artist can have either its ``figure`` or
+        # ``axes`` reference cleared independently, depending on how the axes
+        # was reset.  Attempting to call ``remove`` in this state results in a
+        # ``NotImplementedError`` from Matplotlib.  Only attempt the removal if
+        # both references are still intact and silently swallow any errors so
+        # that stale toggle text never interrupts the caller.
+        if (
+            getattr(text, "figure", None) is not None
+            and getattr(text, "axes", None) is not None
+        ):
             try:
                 text.remove()
             except (ValueError, NotImplementedError):

--- a/tests/test_historical_saver.py
+++ b/tests/test_historical_saver.py
@@ -1,0 +1,34 @@
+import os, sys
+import pandas as pd
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data.historical_saver import save_for_tickers
+
+
+def test_duplicate_columns_are_dropped():
+    records_holder = {}
+
+    def fake_download_raw_option_data(ticker, max_expiries=8):
+        # Minimal non-empty frame so we exercise the rest of the pipeline
+        return pd.DataFrame({"x": [1]})
+
+    def fake_enrich_quotes(raw, r=0.0, q=0.0):
+        # Create DataFrame with duplicate column names
+        return pd.DataFrame([[1, 2]], columns=["a", "a"])
+
+    def fake_insert_quotes(conn, records):
+        records_holder["records"] = records
+        return len(records)
+
+    with patch("data.historical_saver.get_conn", lambda: object()), \
+         patch("data.historical_saver.ensure_initialized", lambda conn: None), \
+         patch("data.historical_saver.download_raw_option_data", fake_download_raw_option_data), \
+         patch("data.historical_saver.enrich_quotes", fake_enrich_quotes), \
+         patch("data.historical_saver.insert_quotes", fake_insert_quotes):
+        total = save_for_tickers(["TST"])
+        assert total == 1
+
+    # After conversion to records only a single key should remain
+    assert list(records_holder["records"][0].keys()) == ["a"]


### PR DESCRIPTION
## Summary
- Drop duplicate columns before inserting records in historical saver to avoid warnings and data loss
- Guard legend toggle text removal against partially detached artists to avoid `NotImplementedError`
- Add regression test ensuring historical saver handles duplicate columns

## Testing
- `pytest tests/test_historical_saver.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7044f2108333bdec9ffe8ede1d05