### PR TITLE
Handle detached legend toggle text

### DIFF
--- a/display/plotting/anim_utils.py
+++ b/display/plotting/anim_utils.py
@@ -367,21 +367,23 @@ def add_legend_toggles(ax: plt.Axes, series_map: Dict[str, List[plt.Artist]]) ->
         text = ax._legend_toggle_text
         # Text may already be detached (e.g. if the axes was cleared) which
         # leaves it without a valid remove method. Guard against this to avoid
-        # ``NotImplementedError`` bubbling up in user code.
+        # exceptions bubbling up in user code.
         #
         # A previously created text artist can have either its ``figure`` or
         # ``axes`` reference cleared independently, depending on how the axes
-        # was reset.  Attempting to call ``remove`` in this state results in a
-        # ``NotImplementedError`` from Matplotlib.  Only attempt the removal if
-        # both references are still intact and silently swallow any errors so
-        # that stale toggle text never interrupts the caller.
+        # was reset.  Attempting to call ``remove`` in this state results in an
+        # exception from Matplotlib.  Only attempt the removal if both
+        # references are still intact and silently swallow any errors so that
+        # stale toggle text never interrupts the caller.
         if (
             getattr(text, "figure", None) is not None
             and getattr(text, "axes", None) is not None
         ):
             try:
                 text.remove()
-            except (ValueError, NotImplementedError):
+            except (ValueError, NotImplementedError, RuntimeError):
+                # ``RuntimeError`` is raised instead of ``NotImplementedError``
+                # in some Matplotlib versions when an artist is detached.
                 pass
 
 


### PR DESCRIPTION
## Summary
- avoid errors when previous legend toggle text is detached

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f72144b2083338766b1079ce77d5d