### PR TITLE
Add Model Params tab to volatility browser

### DIFF
--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -18,6 +18,7 @@ from analysis.analysis_pipeline import available_tickers, available_dates, inges
 from display.gui.gui_input import InputPanel
 from display.gui.gui_plot_manager import PlotManager
 from display.gui.spillover_gui import launch_spillover, SpilloverFrame
+from display.gui.model_params_gui import ModelParamsFrame
 
 
 
@@ -33,9 +34,9 @@ class BrowserApp(tk.Tk):
         self.notebook = ttk.Notebook(self)
         self.notebook.pack(fill=tk.BOTH, expand=True)
 
-        # ---- Model params tab ----
+        # ---- Main browser tab ----
         self.tab_browser = ttk.Frame(self.notebook)
-        self.notebook.add(self.tab_browser, text="Model Params")
+        self.notebook.add(self.tab_browser, text="Browser")
 
         # Inputs
         self.inputs = InputPanel(self.tab_browser, overlay_synth=overlay_synth,
@@ -92,6 +93,10 @@ class BrowserApp(tk.Tk):
         # ---- Spillover tab ----
         self.tab_spillover = SpilloverFrame(self.notebook)
         self.notebook.add(self.tab_spillover, text="Spillover")
+
+        # ---- Model Params tab ----
+        self.tab_modelparams = ModelParamsFrame(self.notebook)
+        self.notebook.add(self.tab_modelparams, text="Model Params")
 
         # Status bar for user feedback
         self.status = ttk.Label(self, text="Ready", anchor="w")

--- a/display/gui/gui_input.py
+++ b/display/gui/gui_input.py
@@ -36,7 +36,6 @@ PLOT_TYPES = (
     "Corr Matrix (ATM)",
     "Synthetic Surface (Smile)",
     "ETF Weights",
-    "Model Params (Time Series)",
 )
 
 class InputPanel(ttk.Frame):

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -10,7 +10,7 @@ from analysis.correlation_utils import corr_weights
 from analysis.beta_builder import pca_weights, pca_weights_from_atm_matrix
 from display.plotting.smile_plot import fit_and_plot_smile
 from display.plotting.term_plot import plot_atm_term_structure
-from analysis.model_params_logger import append_params, load_model_params
+from analysis.model_params_logger import append_params
 
 # surfaces & synth
 from analysis.syntheticETFBuilder import build_surface_grids, combine_surfaces
@@ -114,10 +114,6 @@ class PlotManager:
         self.get_smile_slice = bounded_get_smile_slice
 
         ax.clear()
-
-        if plot_type.startswith("Model Params"):
-            self._plot_model_params(ax, target, model, asof)
-            return
 
         # --- Smile: click-through path (NO df_all needed here) ---
         if plot_type.startswith("Smile"):
@@ -392,30 +388,6 @@ class PlotManager:
                 pass
 
         ax.set_title(title)
-    def _plot_model_params(self, ax, target, model, asof=None):
-        """Plot time-series of fitted model parameters."""
-        df = load_model_params()
-        df = df[(df["ticker"] == target) & (df["model"] == model.lower())]
-        if df.empty:
-            ax.text(0.5, 0.5, f"No parameter data for {target} ({model})", ha="center", va="center")
-            ax.set_title("Model Parameters")
-            return
-        df = df.sort_values("asof_date")
-        if asof:
-            try:
-                cutoff = pd.to_datetime(asof)
-                df = df[df["asof_date"] <= cutoff]
-            except Exception:
-                pass
-        for param_name in df["param"].unique():
-            sub = df[df["param"] == param_name]
-            ax.plot(sub["asof_date"], sub["value"], label=param_name)
-        ax.set_xlabel("Date")
-        ax.set_ylabel("Parameter value")
-        ax.set_title(f"{target} {model.upper()} parameter trends")
-        ax.legend(loc="best", fontsize=8)
-        ax.tick_params(axis="x", rotation=45)
-
     def _plot_synth_surface(self, ax, target, peers, asof, T_days, weight_mode):
         peers = [p for p in peers if p]
         if not peers:

--- a/display/gui/model_params_gui.py
+++ b/display/gui/model_params_gui.py
@@ -1,0 +1,112 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from pathlib import Path
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import sys
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from analysis.model_params_logger import load_model_params
+
+
+class ModelParamsFrame(ttk.Frame):
+    """Frame providing a simple interface for model parameter time-series."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        self.pack(fill=tk.BOTH, expand=True)
+
+        ctrl = ttk.Frame(self)
+        ctrl.pack(side=tk.TOP, fill=tk.X, padx=5, pady=5)
+
+        ttk.Label(ctrl, text="Ticker:").grid(row=0, column=0, sticky=tk.W)
+        self.ent_ticker = ttk.Entry(ctrl, width=12)
+        self.ent_ticker.grid(row=0, column=1, padx=4)
+
+        ttk.Label(ctrl, text="Model:").grid(row=0, column=2, sticky=tk.W)
+        self.cmb_model = ttk.Combobox(ctrl, values=["svi", "sabr", "tps"], width=8, state="readonly")
+        self.cmb_model.set("svi")
+        self.cmb_model.grid(row=0, column=3, padx=4)
+
+        ttk.Label(ctrl, text="As of ≤:").grid(row=0, column=4, sticky=tk.W)
+        self.ent_asof = ttk.Entry(ctrl, width=12)
+        self.ent_asof.grid(row=0, column=5, padx=4)
+
+        btn_plot = ttk.Button(ctrl, text="Plot", command=self._plot)
+        btn_plot.grid(row=0, column=6, padx=4)
+
+        self.fig = plt.Figure(figsize=(6, 4))
+        self.ax = self.fig.add_subplot(1, 1, 1)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+    def _plot(self):
+        ticker = self.ent_ticker.get().strip().upper()
+        model = self.cmb_model.get().strip().lower()
+        asof = self.ent_asof.get().strip()
+
+        self.ax.clear()
+        if not ticker:
+            self.ax.text(0.5, 0.5, "Enter ticker", ha="center", va="center")
+            self.canvas.draw()
+            return
+
+        df = load_model_params()
+        df = df[(df["ticker"] == ticker) & (df["model"] == model)]
+        if asof:
+            try:
+                cutoff = pd.to_datetime(asof)
+                df = df[df["asof_date"] <= cutoff]
+            except Exception:
+                messagebox.showerror("Input error", "Invalid asof date")
+                self.canvas.draw()
+                return
+        if df.empty:
+            self.ax.text(0.5, 0.5, "No parameter data", ha="center", va="center")
+            self.ax.set_title("Model Parameters")
+            self.canvas.draw()
+            return
+
+        df = df.sort_values("asof_date")
+        for param_name in df["param"].unique():
+            sub = df[df["param"] == param_name]
+            self.ax.plot(sub["asof_date"], sub["value"], label=param_name)
+        self.ax.set_xlabel("Date")
+        self.ax.set_ylabel("Parameter value")
+        self.ax.set_title(f"{ticker} {model.upper()} parameter trends")
+        self.ax.legend(loc="best", fontsize=8)
+        self.ax.tick_params(axis="x", rotation=45)
+        self.canvas.draw()
+
+
+class ModelParamsApp(tk.Tk):
+    """Standalone application wrapper for :class:`ModelParamsFrame`."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("Model Parameters Viewer")
+        self.geometry("900x700")
+        panel = ModelParamsFrame(self)
+        panel.pack(fill=tk.BOTH, expand=True)
+
+
+def launch_model_params(parent=None):
+    """Launch the model parameters viewer window."""
+    if parent is None:
+        return ModelParamsApp()
+    else:
+        window = tk.Toplevel(parent)
+        window.title("Model Parameters Viewer")
+        window.geometry("900x700")
+        panel = ModelParamsFrame(window)
+        panel.pack(fill=tk.BOTH, expand=True)
+        return window
+
+
+if __name__ == "__main__":
+    app = launch_model_params()
+    app.mainloop()


### PR DESCRIPTION
## Summary
- Add a dedicated `Model Params` tab to the GUI and rename the main tab to `Browser`
- Remove `Model Params` option from primary plot types
- Provide a standalone `ModelParamsFrame` for viewing parameter time-series

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f76b6c5c08333864a808f159acbe3