### PR TITLE
fix: refresh available dates after ingest

### DIFF
--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -179,6 +179,8 @@ class BrowserApp(tk.Tk):
                 def done():
                     messagebox.showinfo("Download complete", f"Ingested rows: {inserted}\nTickers: {', '.join(universe)}")
                     self.status.config(text=f"Downloaded data for {', '.join(universe)}")
+                    # In-memory caches may still hold old date lists
+                    available_dates.cache_clear()
                     # Refresh available dates now that new data may be present
                     self._on_target_change()
                     self.inputs.btn_download.config(state=tk.NORMAL)


### PR DESCRIPTION
## Summary
- clear cached date list in GUI after new data is ingested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f79d678908333a83b47b522d669e2