### PR TITLE
Enable animation for smile plots

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -26,7 +26,6 @@ from matplotlib.animation import FuncAnimation
 
 from analysis.pillars import atm_curve_for_ticker_on_date
 from display.plotting.anim_utils import animate_surface_timesweep
-# Removed animate_smile_over_time import as smile animations are disabled
 DEFAULT_ATM_BAND = ATM_BAND = 0.05
 def _cols_to_days(cols) -> np.ndarray:
     out = []
@@ -854,9 +853,7 @@ class PlotManager:
     
     def has_animation_support(self, plot_type: str) -> bool:
         """Check if a plot type supports animation."""
-        # Disable time-lapse animation for smile plots as requested
-        # return plot_type.startswith("Smile") or plot_type.startswith("Synthetic Surface")
-        return plot_type.startswith("Synthetic Surface")  # Only surfaces, no smile animations
+        return plot_type.startswith("Smile") or plot_type.startswith("Synthetic Surface")
     
     def is_animation_active(self) -> bool:
         """Check if an animation is currently active."""

--- a/tests/test_gui_animation_support.py
+++ b/tests/test_gui_animation_support.py
@@ -1,0 +1,11 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from display.gui.gui_plot_manager import PlotManager
+
+
+def test_has_animation_support_smile_and_surface():
+    mgr = PlotManager()
+    assert mgr.has_animation_support("Smile (K/S vs IV)")
+    assert mgr.has_animation_support("Synthetic Surface (Smile)")
+    assert not mgr.has_animation_support("Term (ATM)")


### PR DESCRIPTION
## Summary
- Allow smile plots to use animation by extending `has_animation_support`
- Include regression test covering smile and surface animation support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8c340840833395f8cd4bae564249