### PR TITLE
Fix correlation heatmap shifting in GUI

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -100,7 +100,12 @@ class PlotManager:
             if hasattr(ax.figure, '_correlation_colorbar'):
                 ax.figure._correlation_colorbar.remove()
                 delattr(ax.figure, '_correlation_colorbar')
-        except:
+                if hasattr(ax.figure, '_orig_position'):
+                    ax.set_position(ax.figure._orig_position)
+                if hasattr(ax.figure, '_orig_subplotpars'):
+                    l, r, b, t = ax.figure._orig_subplotpars
+                    ax.figure.subplots_adjust(left=l, right=r, bottom=b, top=t)
+        except Exception:
             pass
 
     # ---- main entry ----

--- a/display/plotting/correlation_detail_plot.py
+++ b/display/plotting/correlation_detail_plot.py
@@ -240,20 +240,24 @@ def plot_correlation_details(
         )
 
     im = ax.imshow(data, vmin=-1.0, vmax=1.0, cmap="coolwarm", interpolation="nearest")
-    
-    # Remove any existing colorbar to prevent accumulation
+
+    if not hasattr(ax.figure, '_orig_position'):
+        ax.figure._orig_position = ax.get_position().bounds
+        sp = ax.figure.subplotpars
+        ax.figure._orig_subplotpars = (sp.left, sp.right, sp.bottom, sp.top)
+
+    # Add or update correlation-specific colorbar
     if hasattr(ax.figure, '_correlation_colorbar'):
         try:
-            ax.figure._correlation_colorbar.remove()
-        except:
+            ax.figure._correlation_colorbar.update_normal(im)
+        except Exception:
             pass
-    
-    # Add correlation-specific colorbar only for correlation matrices
-    try:
-        cbar = ax.figure.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
-        ax.figure._correlation_colorbar = cbar
-    except Exception:
-        pass
+    else:
+        try:
+            cbar = ax.figure.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+            ax.figure._correlation_colorbar = cbar
+        except Exception:
+            pass
 
     ax.set_xticks(range(len(corr_df.columns)))
     ax.set_yticks(range(len(corr_df.index)))

--- a/tests/test_corr_colorbar_restore.py
+++ b/tests/test_corr_colorbar_restore.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from display.plotting.correlation_detail_plot import plot_correlation_details
+
+
+def test_repeated_correlation_plot_keeps_axes_position():
+    corr_df = pd.DataFrame(
+        [[1.0, 0.5], [0.5, 1.0]],
+        columns=["A", "B"],
+        index=["A", "B"],
+    )
+    fig, ax = plt.subplots()
+    plot_correlation_details(ax, corr_df, show_values=False)
+    pos1 = ax.get_position().bounds
+    plot_correlation_details(ax, corr_df, show_values=False)
+    pos2 = ax.get_position().bounds
+    assert pos1 == pos2


### PR DESCRIPTION
## Summary
- prevent repeated correlation plots from shifting the heatmap left by preserving the original axes layout and updating the existing colorbar
- add regression test ensuring axes position remains stable across plots

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3228d72e483339b1d863a6e7c97dc