### PR TITLE
Add target rotation utility for correlation analysis

### DIFF
--- a/analysis/correlation_utils.py
+++ b/analysis/correlation_utils.py
@@ -289,3 +289,39 @@ def corr_weights(
     if not np.isfinite(total) or total <= 0:
         return pd.Series(1.0 / max(len(peers), 1), index=peers, dtype=float)
     return (s / total).fillna(0.0)
+
+
+def shift_target(
+    target: str,
+    tickers: Iterable[str],
+    shift: int = 1,
+) -> tuple[str, list[str]]:
+    """Rotate the ticker universe so a different ticker becomes the target.
+
+    Parameters
+    ----------
+    target : str
+        Currently selected target ticker.
+    tickers : Iterable[str]
+        Universe of tickers containing ``target``.
+    shift : int, default 1
+        Number of positions to rotate forward (negative values rotate
+        backward).
+
+    Returns
+    -------
+    tuple[str, list[str]]
+        A tuple of ``(new_target, peers)`` where ``peers`` are the remaining
+        tickers excluding ``new_target`` while preserving their original
+        order.
+    """
+
+    t_list = [t.upper() for t in tickers]
+    if target.upper() not in t_list:
+        raise ValueError("target must be present in tickers")
+
+    idx = t_list.index(target.upper())
+    new_idx = (idx + int(shift)) % len(t_list)
+    new_target = t_list[new_idx]
+    peers = [t for i, t in enumerate(t_list) if i != new_idx]
+    return new_target, peers

--- a/tests/test_shift_target.py
+++ b/tests/test_shift_target.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from analysis.correlation_utils import corr_weights, shift_target
+
+
+def test_shift_target_rotation():
+    corr_df = pd.DataFrame(
+        [
+            [1.0, 0.5, 0.2],
+            [0.5, 1.0, 0.3],
+            [0.2, 0.3, 1.0],
+        ],
+        index=["AAA", "BBB", "CCC"],
+        columns=["AAA", "BBB", "CCC"],
+    )
+
+    target, peers = "AAA", ["BBB", "CCC"]
+    w0 = corr_weights(corr_df, target, peers)
+    assert set(w0.index) == set(peers)
+
+    # Shift forward: BBB becomes target
+    new_target, new_peers = shift_target(target, ["AAA", "BBB", "CCC"])
+    assert new_target == "BBB"
+    assert new_peers == ["AAA", "CCC"]
+    w1 = corr_weights(corr_df, new_target, new_peers)
+    assert set(w1.index) == set(new_peers)
+
+    # Shift backward: return to original target
+    back_target, back_peers = shift_target(new_target, ["AAA", "BBB", "CCC"], shift=-1)
+    assert back_target == target
+    assert back_peers == peers


### PR DESCRIPTION
## Summary
- add `shift_target` helper to rotate which ticker is treated as the target
- test target rotation and integration with correlation weight calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32b7a72f48333a829288be2a075b2