### PR TITLE
Remove CSV fallback and enforce Parquet storage

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -450,26 +450,20 @@ def save_betas(
     benchmark: str,
     base_path: str = "data",
     cfg: PipelineConfig = PipelineConfig(),
-    use_parquet: bool = True,
 ) -> list[str]:
-    """Persist betas to files (Parquet by default for better performance)."""
+    """Persist betas to Parquet files."""
     if mode == "surface":
         # plumb through config to keep in sync with GUI filters
         res = build_vol_betas(
             mode=mode, benchmark=benchmark,
             tenor_days=cfg.tenors, mny_bins=cfg.mny_bins
         )
-        file_ext = "parquet" if use_parquet else "csv"
-        filename = f"betas_{mode}_vs_{benchmark}.{file_ext}"
+        filename = f"betas_{mode}_vs_{benchmark}.parquet"
         p = os.path.join(base_path, filename)
-        
-        if use_parquet:
-            df = res.sort_index().to_frame(name="beta")
-            df.to_parquet(p)
-        else:
-            res.sort_index().to_csv(p, header=True)
+        df = res.sort_index().to_frame(name="beta")
+        df.to_parquet(p)
         return [p]
-    return save_correlations(mode=mode, benchmark=benchmark, base_path=base_path, use_parquet=use_parquet)
+    return save_correlations(mode=mode, benchmark=benchmark, base_path=base_path)
 # =========================
 # Relative value (target vs synthetic peers by corr)
 # =========================
@@ -1041,10 +1035,6 @@ if __name__ == "__main__":
     try:
         paths = save_betas(mode="iv_atm", benchmark="SPY", base_path="data", cfg=cfg)
         print(f"Betas saved to: {[os.path.basename(p) for p in paths]} (Parquet format)")
-        
-        # Also save in CSV format for compatibility demonstration
-        csv_paths = save_betas(mode="iv_atm", benchmark="SPY", base_path="data", cfg=cfg, use_parquet=False)
-        print(f"CSV format also available: {[os.path.basename(p) for p in csv_paths]}")
     except Exception as e:
         print(f"Beta computation skipped: {e}")
 
@@ -1072,9 +1062,8 @@ if __name__ == "__main__":
     print()
     print("=== Enhanced Caching Features ===")
     print("✓ Parquet format for 35%+ size reduction and better performance")
-    print("✓ Configuration-aware cache validation") 
+    print("✓ Configuration-aware cache validation")
     print("✓ Cache management utilities (get_cache_info, clear_all_caches)")
-    print("✓ Backwards compatibility with CSV format")
     print("✓ Smart invalidation when settings change")
         
     # Optional: Demonstrate fitting and sampling 

--- a/analysis/beta_builder.py
+++ b/analysis/beta_builder.py
@@ -816,42 +816,25 @@ def save_correlations(
     mode: str,
     benchmark: str,
     base_path: str = "data",
-    use_parquet: bool = True,
     **kwargs,
 ) -> list[str]:
-    """Persist beta/correlation metrics to files (Parquet by default, CSV optional).
-    
-    Parameters
-    ----------
-    use_parquet : bool, default True
-        If True, save as Parquet files for better performance and compression.
-        If False, save as CSV files for compatibility.
-    """
+    """Persist beta/correlation metrics to Parquet files."""
     res = build_vol_betas(mode=mode, benchmark=benchmark, **kwargs)
     os.makedirs(base_path, exist_ok=True)
     paths: list[str] = []
-    
-    file_ext = "parquet" if use_parquet else "csv"
-
     if isinstance(res, dict):
         for pillar, ser in res.items():
-            filename = f"betas_{mode}_{int(pillar)}d_vs_{benchmark}.{file_ext}"
+            filename = f"betas_{mode}_{int(pillar)}d_vs_{benchmark}.parquet"
             p = os.path.join(base_path, filename)
-            if use_parquet:
-                # Convert Series to DataFrame for parquet compatibility
-                df = ser.sort_index().to_frame(name="beta")
-                df.to_parquet(p)
-            else:
-                ser.sort_index().to_csv(p, header=True)
+            # Convert Series to DataFrame for parquet compatibility
+            df = ser.sort_index().to_frame(name="beta")
+            df.to_parquet(p)
             paths.append(p)
     else:
-        filename = f"betas_{mode}_vs_{benchmark}.{file_ext}"
+        filename = f"betas_{mode}_vs_{benchmark}.parquet"
         p = os.path.join(base_path, filename)
-        if use_parquet:
-            # Convert Series to DataFrame for parquet compatibility
-            df = res.sort_index().to_frame(name="beta")
-            df.to_parquet(p)
-        else:
-            res.sort_index().to_csv(p, header=True)
+        # Convert Series to DataFrame for parquet compatibility
+        df = res.sort_index().to_frame(name="beta")
+        df.to_parquet(p)
         paths.append(p)
     return paths

--- a/display/plotting/correlation_detail_plot.py
+++ b/display/plotting/correlation_detail_plot.py
@@ -323,7 +323,7 @@ def scatter_corr_matrix(
     If ``plot`` is True, the scatter-matrix uses pandas.plotting.scatter_matrix().
     """
     if isinstance(df_or_path, str):
-        df = pd.read_csv(df_or_path)
+        df = pd.read_parquet(df_or_path)
     else:
         df = df_or_path.copy()
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,6 @@ python examples/caching_improvements_demo.py
 - **41%+ file size reduction** with Parquet format
 - **Smart cache invalidation** prevents unnecessary recomputation
 - **Configuration-aware caching** automatically handles settings changes
-- **Backwards compatibility** with CSV format when needed
 
 This demo answers the original questions from issue #47:
 - "Should this be cached in CSVs or would using parquet be more effective?" → **Parquet is more effective**

--- a/examples/caching_improvements_demo.py
+++ b/examples/caching_improvements_demo.py
@@ -24,7 +24,6 @@ from analysis.analysis_pipeline import (
     is_cache_valid,
     load_surface_from_cache_if_valid,
     load_surface_from_cache,
-    save_betas,
     clear_all_caches,
     clear_config_dependent_caches,
     cleanup_disk_cache
@@ -98,28 +97,21 @@ def demo_parquet_benefits():
                 name="beta"
             )
             bb.build_vol_betas = lambda **kwargs: sample_betas
-            
+
             try:
-                # Test both formats
+                # Test Parquet output
                 start_time = time.time()
                 parquet_paths = save_correlations(
-                    mode="demo", benchmark="SPY", 
-                    base_path=tmp_dir, use_parquet=True
+                    mode="demo", benchmark="SPY",
+                    base_path=tmp_dir
                 )
                 parquet_time = time.time() - start_time
-                
-                start_time = time.time()
-                csv_paths = save_correlations(
-                    mode="demo", benchmark="SPY",
-                    base_path=tmp_dir, use_parquet=False
-                )
-                csv_time = time.time() - start_time
-                
                 parquet_size = os.path.getsize(parquet_paths[0])
-                csv_size = os.path.getsize(csv_paths[0])
-                
-                print(f"  save_correlations() - Size reduction: {(1 - parquet_size/csv_size)*100:.1f}%")
-                print(f"  save_correlations() - Write time: Parquet {parquet_time*1000:.1f}ms vs CSV {csv_time*1000:.1f}ms")
+
+                print(
+                    f"  save_correlations() - Parquet write time: {parquet_time*1000:.1f}ms, "
+                    f"size: {parquet_size:,} bytes"
+                )
                 
             finally:
                 if original_func:
@@ -501,11 +493,6 @@ def main():
         print("   ✅ Selective cache clearing (all vs config-dependent)")
         print("   ✅ Automatic cleanup of old cache files")
         print("   ✅ Memory usage tracking and optimization")
-        print()
-        print("🔄 BACKWARDS COMPATIBILITY:")
-        print("   ✅ CSV format still available when needed")
-        print("   ✅ Gradual migration path for existing code")
-        print("   ✅ No breaking changes to existing APIs")
         print()
         print("💡 KEY BENEFITS:")
         print("   • Faster application startup with cached data")


### PR DESCRIPTION
## Summary
- Drop `use_parquet` flags so betas and correlations are always saved as Parquet
- Update examples and documentation to reflect Parquet-only usage
- Read Parquet data in plotting utility instead of CSV

## Testing
- `pytest` *(fails: tests/test_gui_animation_support.py::test_has_animation_support_smile_and_surface, tests/test_pipeline_routes.py::test_compute_peer_weights_dispatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a33deaa550833399a2c42821417fcd