### PR TITLE
Use unified weight computation

### DIFF
--- a/tests/test_weight_mode_recalc.py
+++ b/tests/test_weight_mode_recalc.py
@@ -14,26 +14,19 @@ def test_weights_recomputed_on_weight_mode_change(monkeypatch):
     )
     pm.last_corr_meta = {"weight_mode": "iv_atm"}
 
-    calls = {"corr": 0, "compute": 0}
+    calls = {"compute": 0}
 
-    def fake_corr_weights(df, target, peers, clip_negative=True, power=1.0):
-        calls["corr"] += 1
-        return pd.Series({peers[0]: 1.0})
-
-    def fake_compute_peer_weights(target, peers, weight_mode, asof=None, pillar_days=None, tenor_days=None, mny_bins=None):
+    def fake_compute_unified_weights(
+        target, peers, mode, power=1.0, clip_negative=True, pillars_days=None, asof=None
+    ):
         calls["compute"] += 1
         return pd.Series({peers[0]: 1.0})
 
     monkeypatch.setattr(
-        "display.gui.gui_plot_manager.corr_weights", fake_corr_weights
-    )
-    monkeypatch.setattr(
-        "analysis.analysis_pipeline.compute_peer_weights", fake_compute_peer_weights
+        "analysis.unified_weights.compute_unified_weights", fake_compute_unified_weights
     )
 
     pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "iv_atm")
-    assert calls["corr"] == 1 and calls["compute"] == 0
-
     pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "ul")
-    assert calls["corr"] == 1
-    assert calls["compute"] == 1
+
+    assert calls["compute"] == 2


### PR DESCRIPTION
## Summary
- Remove legacy corr_weights fallback and delegate weight computation to unified compute_unified_weights
- Update test to mock unified weight computation for recomputation checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a349c543848333b0f1b850af5a65e0