### PR TITLE
Add parameter summary tab and rename explorer

### DIFF
--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -25,6 +25,7 @@ from analysis.analysis_pipeline import available_tickers, available_dates, inges
 from display.gui.gui_input import InputPanel
 from display.gui.gui_plot_manager import PlotManager
 from display.gui.spillover_gui import launch_spillover, SpilloverFrame
+from display.gui.parameters_tab import ParametersTab
 
 
 class BrowserApp(tk.Tk):
@@ -39,9 +40,10 @@ class BrowserApp(tk.Tk):
         self.notebook = ttk.Notebook(self)
         self.notebook.pack(fill=tk.BOTH, expand=True)
 
-        # ---- Model params tab ----
+        # ---- Main exploration tab ----
         self.tab_browser = ttk.Frame(self.notebook)
-        self.notebook.add(self.tab_browser, text="Model Params")
+        # Clarify purpose: this tab lets users explore IV surfaces
+        self.notebook.add(self.tab_browser, text="Parameter Explorer")
 
         # Inputs
         self.inputs = InputPanel(self.tab_browser, overlay_synth=overlay_synth,
@@ -96,6 +98,10 @@ class BrowserApp(tk.Tk):
 
         self.plot_mgr = PlotManager()
         self.plot_mgr.attach_canvas(self.canvas)
+
+        # ---- Parameter summary tab ----
+        self.tab_params = ParametersTab(self.notebook)
+        self.notebook.add(self.tab_params, text="Parameter Summary")
 
         # ---- Spillover tab ----
         self.tab_spillover = SpilloverFrame(self.notebook)
@@ -257,6 +263,8 @@ class BrowserApp(tk.Tk):
                 self.canvas.draw()
                 self.after(0, self._update_nav_buttons)
                 self.after(0, self._update_animation_buttons)
+                # Refresh parameter table with latest fit info
+                self.after(0, lambda: self.tab_params.update(self.plot_mgr.last_fit_info))
 
             except Exception as e:
                 def handle_err(exc: Exception):

--- a/display/gui/parameters_tab.py
+++ b/display/gui/parameters_tab.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import tkinter as tk
+from tkinter import ttk
+from typing import Dict, Any
+
+
+class ParametersTab(ttk.Frame):
+    """Simple table view for model and sensitivity parameters."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        cols = ("Model", "Parameter", "Value")
+        self.tree = ttk.Treeview(self, columns=cols, show="headings")
+        for c in cols:
+            self.tree.heading(c, text=c)
+            self.tree.column(c, anchor=tk.W, stretch=True)
+        self.tree.pack(fill=tk.BOTH, expand=True)
+
+    def update(self, info: Dict[str, Any] | None) -> None:
+        """Update table with latest fit information."""
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        if not info:
+            return
+
+        def insert(model: str, params: Dict[str, Any]):
+            for k, v in params.items():
+                try:
+                    val = float(v)
+                except Exception:
+                    continue
+                self.tree.insert("", tk.END, values=(model, k, f"{val:.6g}"))
+
+        if info.get("svi"):
+            insert("SVI", info["svi"])
+        if info.get("sabr"):
+            insert("SABR", info["sabr"])
+        if info.get("sens"):
+            insert("Sensitivity", info["sens"])


### PR DESCRIPTION
## Summary
- Rename the main IV browser tab to "Parameter Explorer" for clarity
- Add a new "Parameter Summary" tab that lists SVI, SABR and sensitivity parameters
- Log parameters for both SVI and SABR fits and update UI after plotting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35c28454c833384f179f0674fc19a