### PR TITLE
Add open interest weighting capability and database support

### DIFF
--- a/analysis/unified_weights.py
+++ b/analysis/unified_weights.py
@@ -23,6 +23,7 @@ class WeightMethod(Enum):
     PCA = "pca"
     COSINE = "cosine"
     EQUAL = "equal"
+    OPEN_INTEREST = "oi"
 
 
 class FeatureSet(Enum):
@@ -67,6 +68,8 @@ class WeightConfig:
             "pca": WeightMethod.PCA,
             "cosine": WeightMethod.COSINE,
             "equal": WeightMethod.EQUAL,
+            "oi": WeightMethod.OPEN_INTEREST,
+            "open_interest": WeightMethod.OPEN_INTEREST,
             "iv": WeightMethod.CORRELATION,  # Legacy fallback
         }
         
@@ -119,6 +122,9 @@ class UnifiedWeightComputer:
         if config.method == WeightMethod.EQUAL:
             weight = 1.0 / len(peers_list)
             return pd.Series(weight, index=peers_list, dtype=float)
+
+        if config.method == WeightMethod.OPEN_INTEREST:
+            return self._open_interest_weights(peers_list, config.asof)
         
         # Get as-of date
         asof = config.asof
@@ -218,6 +224,41 @@ class UnifiedWeightComputer:
         
         subset = vol[[c for c in tickers if c in vol.columns]]
         return subset.T if not subset.empty else None
+
+    def _open_interest_weights(self, peers_list: list[str], asof: Optional[str]) -> pd.Series:
+        """Compute weights proportional to total open interest for each peer."""
+        from data.db_utils import get_conn
+
+        if not peers_list:
+            return pd.Series(dtype=float)
+        conn = get_conn()
+        if asof is None:
+            # Fallback to most recent date available for each ticker
+            # but for simplicity we'll use MAX(asof_date) overall
+            asof_row = conn.execute(
+                "SELECT MAX(asof_date) FROM options_quotes WHERE ticker IN ({})".format(
+                    ",".join("?" * len(peers_list))
+                ),
+                peers_list,
+            ).fetchone()
+            asof = asof_row[0] if asof_row and asof_row[0] else None
+            if asof is None:
+                return self._fallback_weights(peers_list)
+
+        query = (
+            "SELECT ticker, SUM(open_interest) AS oi FROM options_quotes "
+            "WHERE asof_date = ? AND ticker IN ({}) GROUP BY ticker"
+        ).format(",".join("?" * len(peers_list)))
+        df = pd.read_sql_query(query, conn, params=[asof] + peers_list)
+        if df.empty:
+            return self._fallback_weights(peers_list)
+        series = pd.Series(df["oi"].values, index=df["ticker"].str.upper())
+        total = series.sum()
+        if total <= 0:
+            return self._fallback_weights(peers_list)
+        weights = series / total
+        # Ensure all peers present; missing ones get zero weight
+        return weights.reindex([p.upper() for p in peers_list]).fillna(0.0)
     
     def _compute_weights_from_features(
         self,

--- a/data/data_downloader.py
+++ b/data/data_downloader.py
@@ -46,7 +46,7 @@ def download_raw_option_data(ticker: str, max_expiries: int = 8) -> pd.DataFrame
             if df is None or df.empty:
                 continue
             # keep only raw vendor columns we need
-            sub = df.loc[:, ["strike", "impliedVolatility", "bid", "ask", "lastPrice", "volume"]].copy()
+            sub = df.loc[:, ["strike", "impliedVolatility", "bid", "ask", "lastPrice", "volume", "openInterest"]].copy()
             for _, r in sub.iterrows():
                 rows.append(
                     {
@@ -60,6 +60,7 @@ def download_raw_option_data(ticker: str, max_expiries: int = 8) -> pd.DataFrame
                         "ask_raw": None if pd.isna(r["ask"]) else float(r["ask"]),
                         "last_raw": None if pd.isna(r["lastPrice"]) else float(r["lastPrice"]),
                         "volume_raw": None if pd.isna(r["volume"]) else float(r["volume"]),
+                        "open_interest_raw": None if pd.isna(r["openInterest"]) else float(r["openInterest"]),
                         "spot_raw": float(spot),
                         "vendor": "yfinance",
                     }

--- a/data/data_pipeline.py
+++ b/data/data_pipeline.py
@@ -88,12 +88,12 @@ def enrich_quotes(
     cols = [
         "asof_date", "ticker", "expiry", "K", "call_put",
         "sigma", "S", "T", "moneyness", "log_moneyness", "delta", "is_atm",
-        "volume_raw", "bid_raw", "ask_raw", "last_raw",
+        "volume_raw", "open_interest_raw", "bid_raw", "ask_raw", "last_raw",
         "r", "q", "price", "gamma", "vega", "theta", "rho", "d1", "d2",
         "vendor"
     ]
     # Some raw cols may be missing; add if needed
-    for c in ["volume_raw", "bid_raw", "ask_raw", "last_raw"]:
+    for c in ["volume_raw", "open_interest_raw", "bid_raw", "ask_raw", "last_raw"]:
         if c not in out.columns:
             out[c] = None
 

--- a/data/db_schema.py
+++ b/data/db_schema.py
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS options_quotes (
     delta          REAL,
     is_atm         INTEGER,
     volume         REAL,
+    open_interest  REAL,
     bid            REAL,
     ask            REAL,
     mid            REAL,
@@ -94,6 +95,7 @@ MIGRATIONS = [
     ("rho", "ALTER TABLE options_quotes ADD COLUMN rho REAL"),
     ("d1", "ALTER TABLE options_quotes ADD COLUMN d1 REAL"),
     ("d2", "ALTER TABLE options_quotes ADD COLUMN d2 REAL"),
+    ("open_interest", "ALTER TABLE options_quotes ADD COLUMN open_interest REAL"),
 ]
 
 def init_db(conn: sqlite3.Connection) -> None:

--- a/tests/test_open_interest_weights.py
+++ b/tests/test_open_interest_weights.py
@@ -1,0 +1,43 @@
+import sqlite3
+
+import pytest
+
+from data.db_utils import ensure_initialized, insert_quotes
+from analysis.unified_weights import compute_unified_weights
+
+
+def test_open_interest_weighting(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    ensure_initialized(conn)
+
+    quotes = [
+        {
+            "asof_date": "2024-01-01",
+            "ticker": "AAA",
+            "expiry": "2024-02-01",
+            "K": 100,
+            "call_put": "C",
+            "open_interest": 100,
+        },
+        {
+            "asof_date": "2024-01-01",
+            "ticker": "BBB",
+            "expiry": "2024-02-01",
+            "K": 100,
+            "call_put": "C",
+            "open_interest": 300,
+        },
+    ]
+    insert_quotes(conn, quotes)
+
+    monkeypatch.setattr("data.db_utils.get_conn", lambda db_path=None: conn)
+
+    weights = compute_unified_weights(
+        target="TGT",
+        peers=["AAA", "BBB"],
+        mode="oi",
+        asof="2024-01-01",
+    )
+
+    assert weights.loc["AAA"] == pytest.approx(0.25)
+    assert weights.loc["BBB"] == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- download and store per-contract open interest from Yahoo Finance
- add open-interest-aware weight mode (`oi`) to unified weighting system
- test open interest weighting logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36b7529448333bbbed76d6f60229a