### PR TITLE
Allow synthetic surface viewer to render with disjoint dates

### DIFF
--- a/tests/test_synthetic_etf_plotting.py
+++ b/tests/test_synthetic_etf_plotting.py
@@ -2,6 +2,13 @@ import numpy as np
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+import pandas as pd
+
+from analysis.analysis_synthetic_etf import SyntheticETFArtifacts
+from display.plotting.display_viewers_synthetic_etf_viewer import (
+    show_synthetic_etf,
+    _extract_latest,
+)
 
 from display.plotting.smile_plot import plot_synthetic_etf_smile
 from display.plotting.term_plot import plot_synthetic_etf_term_structure
@@ -31,3 +38,29 @@ def test_plot_synthetic_etf_term_structure_runs():
     bands = plot_synthetic_etf_term_structure(ax, atm_data, weights, pillar_days, n_boot=5)
     assert bands.mean.shape == pillar_days.shape
     plt.close(fig)
+
+
+def test_show_synthetic_etf_handles_disjoint_dates(monkeypatch):
+    df_tgt = pd.DataFrame(
+        [[0.2, 0.21], [0.22, 0.23]],
+        index=["0.9", "1.1"],
+        columns=["30", "60"],
+    )
+    df_syn = pd.DataFrame(
+        [[0.25, 0.24], [0.26, 0.23]],
+        index=["0.9", "1.1"],
+        columns=["30", "60"],
+    )
+    artifacts = SyntheticETFArtifacts(
+        weights=pd.Series(dtype=float),
+        surfaces={"A": {"2024-01-01": df_tgt}},
+        synthetic_surfaces={"2024-01-02": df_syn},
+        rv_metrics=pd.DataFrame(),
+        meta={"target": "A"},
+    )
+    tgt_df, syn_df, d_tgt, d_syn = _extract_latest(artifacts, "A")
+    assert d_tgt == "2024-01-01"
+    assert d_syn == "2024-01-02"
+    assert tgt_df is not None and syn_df is not None
+    monkeypatch.setattr(plt, "show", lambda: None)
+    show_synthetic_etf(artifacts, target="A")


### PR DESCRIPTION
## Summary
- Let synthetic ETF viewer fall back to most recent target and synthetic surfaces when no dates overlap
- Guard RV metrics table rendering and annotate plots when target/synthetic dates differ
- Test that viewer runs with disjoint surface dates

## Testing
- `pytest tests/test_synthetic_etf_plotting.py::test_show_synthetic_etf_handles_disjoint_dates -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36fecde2483338a02c860abbfd4d8