### PR TITLE
Use underlying returns for UL weight mode

### DIFF
--- a/analysis/unified_weights.py
+++ b/analysis/unified_weights.py
@@ -55,14 +55,6 @@ class WeightConfig:
         mode = mode.lower().strip()
         
         # Handle compound modes like "corr_iv_atm", "pca_surface", etc.
-        if "_" in mode:
-            parts = mode.split("_")
-            method_str = parts[0]
-            feature_str = "_".join(parts[1:])
-        else:
-            method_str = mode
-            feature_str = "atm"  # default
-        
         # Map method strings
         method_map = {
             "corr": WeightMethod.CORRELATION,
@@ -74,7 +66,7 @@ class WeightConfig:
             "open_interest": WeightMethod.OPEN_INTEREST,
             "iv": WeightMethod.CORRELATION,  # Legacy fallback
         }
-        
+
         # Map feature strings
         feature_map = {
             "atm": FeatureSet.ATM,
@@ -89,10 +81,22 @@ class WeightConfig:
             "underlying_vol": FeatureSet.UNDERLYING_VOL,
             "ul_vol": FeatureSet.UNDERLYING_VOL,
         }
-        
+
+        # Allow specifying feature set directly (e.g., "ul", "ul_vol")
+        if mode in feature_map:
+            method_str = "corr"
+            feature_str = mode
+        elif "_" in mode:
+            parts = mode.split("_")
+            method_str = parts[0]
+            feature_str = "_".join(parts[1:])
+        else:
+            method_str = mode
+            feature_str = "atm"  # default
+
         method = method_map.get(method_str, WeightMethod.CORRELATION)
         feature_set = feature_map.get(feature_str, FeatureSet.ATM)
-        
+
         return cls(method=method, feature_set=feature_set, **kwargs)
 
 

--- a/tests/test_ul_weights.py
+++ b/tests/test_ul_weights.py
@@ -1,0 +1,52 @@
+import sqlite3
+import numpy as np
+import pandas as pd
+
+from data.db_utils import ensure_initialized
+from analysis.unified_weights import compute_unified_weights
+from analysis.correlation_utils import corr_weights
+
+
+def test_ul_weight_mode_uses_correlation(monkeypatch):
+    conn = sqlite3.connect(":memory:")
+    ensure_initialized(conn)
+
+    prices = [
+        ("2024-01-01", "TGT", 100),
+        ("2024-01-02", "TGT", 101),
+        ("2024-01-03", "TGT", 103),
+        ("2024-01-04", "TGT", 106),
+        ("2024-01-01", "AAA", 10),
+        ("2024-01-02", "AAA", 10.5),
+        ("2024-01-03", "AAA", 11.5),
+        ("2024-01-04", "AAA", 13),
+        ("2024-01-01", "BBB", 20),
+        ("2024-01-02", "BBB", 21),
+        ("2024-01-03", "BBB", 19),
+        ("2024-01-04", "BBB", 20),
+    ]
+    conn.executemany(
+        "INSERT INTO underlying_prices(asof_date, ticker, close) VALUES (?,?,?)",
+        prices,
+    )
+    conn.commit()
+
+    monkeypatch.setattr("data.db_utils.get_conn", lambda db_path=None: conn)
+
+    weights = compute_unified_weights(
+        target="TGT", peers=["AAA", "BBB"], mode="ul", asof="2024-01-04"
+    )
+
+    df = pd.DataFrame(
+        {
+            "TGT": [100, 101, 103, 106],
+            "AAA": [10, 10.5, 11.5, 13],
+            "BBB": [20, 21, 19, 20],
+        }
+    )
+    ret = np.log(df / df.shift(1)).dropna()
+    expected = corr_weights(ret.corr(), "TGT", ["AAA", "BBB"])
+
+    pd.testing.assert_series_equal(
+        weights.rename_axis(None), expected.rename_axis(None)
+    )


### PR DESCRIPTION
## Summary
- Interpret standalone `ul` and `ul_vol` weight modes as correlation-based underlying features
- Add test verifying UL weights derive from underlying return correlations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3716192988333896c3ffc9de36529