### PR TITLE
Improve underlying feature handling and safeguard DB connections

### DIFF
--- a/analysis/beta_builder.py
+++ b/analysis/beta_builder.py
@@ -390,7 +390,12 @@ def iv_atm_betas(benchmark: str, pillar_days: Iterable[int] = DEFAULT_PILLARS_DA
             out[int(pillar)] = pillar_correlations.rename(f"iv_atm_beta_{int(pillar)}d")
             
     finally:
-        conn.close()
+        try:
+            db_path = conn.execute("PRAGMA database_list").fetchone()[2]
+        except Exception:
+            db_path = None
+        if db_path not in (":memory:", "", None):
+            conn.close()
     
     return out
 

--- a/analysis/correlation_utils.py
+++ b/analysis/correlation_utils.py
@@ -317,11 +317,7 @@ def corr_weights(
         print(f"  Available tickers: {list(corr_df.index)}")
         print(f"  Requested peers: {peers}")
         print(f"  Final weights before normalization: {s.to_dict()}")
-        
-        # Fallback to equal weights if all correlations are zero/negative/NaN
-        print(f"  Falling back to equal weights")
-        equal_weight = 1.0 / len(peers)
-        return pd.Series(equal_weight, index=peers)
+        raise ValueError("Correlation weights sum to zero or NaN")
     
     return (s / total).fillna(0.0)
 

--- a/analysis/unified_weights.py
+++ b/analysis/unified_weights.py
@@ -208,24 +208,30 @@ class UnifiedWeightComputer:
         """Build underlying price return features."""
         from analysis.beta_builder import _underlying_log_returns
         from data.db_utils import get_conn
-        
+
         ret = _underlying_log_returns(get_conn)
         if ret.empty:
             return None
-        
+
         subset = ret[[c for c in tickers if c in ret.columns]]
+        subset = subset.dropna(how="all")
+        if subset.shape[0] < 2:
+            return None
         return subset.T if not subset.empty else None
-    
+
     def _build_underlying_vol_features(self, tickers: list[str]) -> Optional[pd.DataFrame]:
         """Build underlying volatility features."""
         from analysis.beta_builder import _underlying_vol_series
         from data.db_utils import get_conn
-        
+
         vol = _underlying_vol_series(get_conn, window=21, min_obs=10)
         if vol.empty:
             return None
-        
+
         subset = vol[[c for c in tickers if c in vol.columns]]
+        subset = subset.dropna(how="all")
+        if subset.shape[0] < 2:
+            return None
         return subset.T if not subset.empty else None
 
     def _open_interest_weights(self, peers_list: list[str], asof: Optional[str]) -> pd.Series:


### PR DESCRIPTION
## Summary
- Drop empty underlying price/volatility rows so feature building fails fast when data is missing
- Raise a clear error when correlation weights sum to zero instead of returning equal weights
- Avoid closing shared database connections in `iv_atm_betas`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37e5c9ee48333b3f22412ca693e0c