### PR TITLE
Write beta data with explicit ticker column

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -479,8 +479,8 @@ def save_betas(
         )
         filename = f"betas_{mode}_vs_{benchmark}.parquet"
         p = os.path.join(base_path, filename)
-        df = res.sort_index().to_frame(name="beta")
-        df.to_parquet(p)
+        df = res.sort_index().to_frame(name="beta").reset_index().rename(columns={"index": "ticker"})
+        df.to_parquet(p, index=False)
         return [p]
     return save_correlations(mode=mode, benchmark=benchmark, base_path=base_path)
 # =========================

--- a/analysis/beta_builder.py
+++ b/analysis/beta_builder.py
@@ -917,14 +917,14 @@ def save_correlations(
             filename = f"betas_{mode}_{int(pillar)}d_vs_{benchmark}.parquet"
             p = os.path.join(base_path, filename)
             # Convert Series to DataFrame for parquet compatibility
-            df = ser.sort_index().to_frame(name="beta")
-            df.to_parquet(p)
+            df = ser.sort_index().to_frame(name="beta").reset_index().rename(columns={"index": "ticker"})
+            df.to_parquet(p, index=False)
             paths.append(p)
     else:
         filename = f"betas_{mode}_vs_{benchmark}.parquet"
         p = os.path.join(base_path, filename)
         # Convert Series to DataFrame for parquet compatibility
-        df = res.sort_index().to_frame(name="beta")
-        df.to_parquet(p)
+        df = res.sort_index().to_frame(name="beta").reset_index().rename(columns={"index": "ticker"})
+        df.to_parquet(p, index=False)
         paths.append(p)
     return paths

--- a/tests/test_parquet_feed.py
+++ b/tests/test_parquet_feed.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from pathlib import Path
+import tempfile
+from analysis import beta_builder
+from analysis import analysis_pipeline
+
+def test_save_correlations_writes_parquet(monkeypatch):
+    sample = pd.Series({'AAA': 0.1, 'BBB': 0.2})
+    monkeypatch.setattr(beta_builder, 'build_vol_betas', lambda **kwargs: sample)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        paths = beta_builder.save_correlations(mode='demo', benchmark='SPY', base_path=tmpdir)
+        assert paths and Path(paths[0]).exists()
+        df = pd.read_parquet(paths[0])
+        assert set(df.columns) == {'ticker', 'beta'}
+        assert set(df['ticker']) == {'AAA', 'BBB'}
+
+
+def test_save_betas_surface_writes_parquet(monkeypatch):
+    sample = pd.Series({'AAA': 0.3, 'BBB': 0.4})
+    monkeypatch.setattr(analysis_pipeline, 'build_vol_betas', lambda *args, **kwargs: sample)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        paths = analysis_pipeline.save_betas(mode='surface', benchmark='SPY', base_path=tmpdir)
+        assert paths and Path(paths[0]).exists()
+        df = pd.read_parquet(paths[0])
+        assert set(df.columns) == {'ticker', 'beta'}
+        assert set(df['ticker']) == {'AAA', 'BBB'}


### PR DESCRIPTION
## Summary
- Reset index when saving betas to parquet so tickers are written as an explicit column
- Ensure surface-mode beta saves also include the ticker column
- Add tests verifying parquet output contains ticker and beta columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a384957e8c8333b57eef0c1c5efe8c