### PR TITLE
Ensure synthetic vol curve appears in legend

### DIFF
--- a/display/plotting/smile_plot.py
+++ b/display/plotting/smile_plot.py
@@ -211,7 +211,9 @@ def plot_synthetic_etf_smile(
 
     ax.set_xlabel("Strike / Moneyness")
     ax.set_ylabel("Implied Vol")
-    if not ax.get_legend():
-        ax.legend(loc="best", fontsize=8)
+    # Always refresh the legend so newly added synthetic curves appear
+    handles, labels = ax.get_legend_handles_labels()
+    if handles and labels:
+        ax.legend(handles, labels, loc="best", fontsize=8)
 
     return bands

--- a/display/plotting/term_plot.py
+++ b/display/plotting/term_plot.py
@@ -220,7 +220,9 @@ def plot_synthetic_etf_term_structure(
 
     ax.set_xlabel("Pillar (days)")
     ax.set_ylabel("Implied Vol (ATM)")
-    if not ax.get_legend():
-        ax.legend(loc="best", fontsize=8)
+    # Refresh legend to ensure synthetic term structure is visible
+    handles, labels = ax.get_legend_handles_labels()
+    if handles and labels:
+        ax.legend(handles, labels, loc="best", fontsize=8)
 
     return bands

--- a/tests/test_synthetic_etf_plotting.py
+++ b/tests/test_synthetic_etf_plotting.py
@@ -26,6 +26,24 @@ def test_plot_synthetic_etf_smile_runs():
     assert bands.mean.shape == grid.shape
     plt.close(fig)
 
+def test_plot_synthetic_etf_smile_adds_to_legend():
+    surfaces = {
+        'A': np.array([0.2, 0.21, 0.22]),
+    }
+    weights = {'A': 1.0}
+    grid = np.array([0.9, 1.0, 1.1])
+
+    fig, ax = plt.subplots()
+    ax.plot(grid, surfaces['A'], label='Target')
+    ax.legend()
+
+    plot_synthetic_etf_smile(ax, surfaces, weights, grid, n_boot=5)
+    legend = ax.get_legend()
+    assert legend is not None
+    labels = [text.get_text() for text in legend.get_texts()]
+    assert 'Synthetic ETF' in labels
+    plt.close(fig)
+
 def test_plot_synthetic_etf_term_structure_runs():
     atm_data = {
         'A': np.array([0.2, 0.21, 0.22]),
@@ -37,6 +55,25 @@ def test_plot_synthetic_etf_term_structure_runs():
     fig, ax = plt.subplots()
     bands = plot_synthetic_etf_term_structure(ax, atm_data, weights, pillar_days, n_boot=5)
     assert bands.mean.shape == pillar_days.shape
+    plt.close(fig)
+
+
+def test_plot_synthetic_etf_term_structure_adds_to_legend():
+    atm_data = {
+        'A': np.array([0.2, 0.21, 0.22]),
+    }
+    weights = {'A': 1.0}
+    pillar_days = np.array([30, 60, 90])
+
+    fig, ax = plt.subplots()
+    ax.plot(pillar_days, atm_data['A'], label='Target')
+    ax.legend()
+
+    plot_synthetic_etf_term_structure(ax, atm_data, weights, pillar_days, n_boot=5)
+    legend = ax.get_legend()
+    assert legend is not None
+    labels = [text.get_text() for text in legend.get_texts()]
+    assert 'Synthetic ATM' in labels
     plt.close(fig)
 
 


### PR DESCRIPTION
## Summary
- refresh legend in synthetic ETF smile and term structure plots so synthetic curves are labeled
- add regression tests verifying legends include synthetic ETF entries

## Testing
- `pytest tests/test_synthetic_etf_plotting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48e3126248333b217017a58b75741