### PR TITLE
Refactor plotting to use precomputed volatility fits

### DIFF
--- a/display/plotting/smile_plot.py
+++ b/display/plotting/smile_plot.py
@@ -5,17 +5,13 @@ from typing import Dict, Optional, Tuple, Literal
 import numpy as np
 import matplotlib.pyplot as plt
 
-from volModel.sviFit import fit_svi_slice, svi_smile_iv
-from volModel.sabrFit import fit_sabr_slice, sabr_smile_iv
-from .confidence_bands import (
-    svi_confidence_bands,
-    sabr_confidence_bands,
-    synthetic_etf_confidence_bands,
-    Bands,
-)
+from volModel.sviFit import svi_smile_iv
+from volModel.sabrFit import sabr_smile_iv
+from volModel.polyFit import tps_smile_iv
+from analysis.confidence_bands import Bands
 from display.plotting.anim_utils import  add_legend_toggles
 
-ModelName = Literal["svi", "sabr"]
+ModelName = Literal["svi", "sabr", "tps"]
 
 
 # ------------------
@@ -46,10 +42,9 @@ def fit_and_plot_smile(
     iv: np.ndarray,
     *,
     model: ModelName = "svi",
-    params: Optional[Dict] = None,
+    params: Dict,
+    bands: Optional[Bands] = None,
     moneyness_grid: Tuple[float, float, int] = (0.8, 1.2, 121),
-    ci_level: float = 0.68,         # confidence level (0 disables CI)
-    n_boot: int = 200,              # used only if ci_level > 0
     show_points: bool = True,
     beta: float = 0.5,              # SABR beta
     label: Optional[str] = None,
@@ -96,20 +91,15 @@ def fit_and_plot_smile(
             series_map["Observed Points"] = [pts]
 
     # ---- fit + optional CI
-    bands: Optional[Bands] = None
-    fit_params = params or {}
+    if not params:
+        raise ValueError("fit parameters must be provided")
+    fit_params = params
     if model == "svi":
-        if not fit_params:
-            fit_params = fit_svi_slice(S, K, T, iv)
         y_fit = svi_smile_iv(S, K_grid, T, fit_params)
-        if ci_level and ci_level > 0:
-            bands = svi_confidence_bands(S, K, T, iv, K_grid, level=float(ci_level), n_boot=int(n_boot))
-    else:
-        if not fit_params:
-            fit_params = fit_sabr_slice(S, K, T, iv, beta=beta)
+    elif model == "sabr":
         y_fit = sabr_smile_iv(S, K_grid, T, fit_params)
-        if ci_level and ci_level > 0:
-            bands = sabr_confidence_bands(S, K, T, iv, K_grid, beta=beta, level=float(ci_level), n_boot=int(n_boot))
+    else:
+        y_fit = tps_smile_iv(S, K_grid, T, fit_params)
 
     # ---- fit line
     line_kwargs = dict(line_kwargs or {})
@@ -121,7 +111,7 @@ def fit_and_plot_smile(
 
     # ---- confidence bands
     if bands is not None:
-        ci_fill = ax.fill_between(bands.x / S, bands.lo, bands.hi, alpha=0.20, label=f"{int(ci_level*100)}% CI")
+        ci_fill = ax.fill_between(bands.x / S, bands.lo, bands.hi, alpha=0.20, label=f"{int(bands.level*100)}% CI")
         ci_mean = ax.plot(bands.x / S, bands.mean, lw=1, alpha=0.6, linestyle="--")
         if enable_svi_toggles and model == "svi":
             series_map["SVI Confidence Interval"] = [ci_fill, *ci_mean]
@@ -160,50 +150,14 @@ def fit_and_plot_smile(
 
 def plot_synthetic_etf_smile(
     ax: plt.Axes,
-    surfaces: Dict[str, np.ndarray],
-    weights: Dict[str, float],
-    grid: np.ndarray,
+    bands: Bands,
     *,
-    level: float = 0.68,
-    n_boot: int = 200,
     label: Optional[str] = "Synthetic ETF",
     line_kwargs: Optional[Dict] = None,
 ) -> Bands:
-    """Plot synthetic ETF smile with confidence bands.
+    """Plot synthetic ETF smile using pre-computed confidence bands."""
 
-    Parameters
-    ----------
-    ax : plt.Axes
-        Axis to render on.
-    surfaces : dict
-        ``{ticker -> iv_array}`` aligned to ``grid``.
-    weights : dict
-        ``{ticker -> weight}`` for the synthetic combination.
-    grid : np.ndarray
-        Strike or moneyness grid.
-    level : float, optional
-        Confidence level for the bands.
-    n_boot : int, optional
-        Number of bootstrap samples.
-    label : str, optional
-        Legend label for the mean line.
-    line_kwargs : dict, optional
-        Extra kwargs for the mean line.
-
-    Returns
-    -------
-    Bands
-        Bootstrap bands for the synthetic smile.
-    """
-    bands = synthetic_etf_confidence_bands(
-        surfaces=surfaces,
-        weights=weights,
-        grid_K=np.asarray(grid, float),
-        level=level,
-        n_boot=n_boot,
-    )
-
-    ax.fill_between(bands.x, bands.lo, bands.hi, alpha=0.20, label=f"CI ({int(level*100)}%)")
+    ax.fill_between(bands.x, bands.lo, bands.hi, alpha=0.20, label=f"CI ({int(bands.level*100)}%)")
 
     line_kwargs = dict(line_kwargs or {})
     line_kwargs.setdefault("lw", 1.8)
@@ -211,7 +165,6 @@ def plot_synthetic_etf_smile(
 
     ax.set_xlabel("Strike / Moneyness")
     ax.set_ylabel("Implied Vol")
-    # Always refresh the legend so newly added synthetic curves appear
     handles, labels = ax.get_legend_handles_labels()
     if handles and labels:
         ax.legend(handles, labels, loc="best", fontsize=8)

--- a/display/plotting/term_plot.py
+++ b/display/plotting/term_plot.py
@@ -5,108 +5,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from typing import Optional, Dict
 
-from display.plotting.confidence_bands import (
-    bootstrap_bands,
-    synthetic_etf_pillar_bands,
-    Bands,
-)
-
-
-def _polynomial_fit_fn(x: np.ndarray, y: np.ndarray, degree: int = 2) -> dict:
-    """Fit polynomial to term structure data."""
-    x = np.asarray(x, dtype=float)
-    y = np.asarray(y, dtype=float)
-    
-    # Remove NaN values
-    mask = np.isfinite(x) & np.isfinite(y)
-    if np.sum(mask) < degree + 1:
-        # Not enough points for the requested degree
-        degree = max(1, np.sum(mask) - 1)
-    
-    if np.sum(mask) < 2:
-        # Fallback to constant
-        return {"coeffs": [np.nanmean(y)], "degree": 0}
-    
-    try:
-        coeffs = np.polyfit(x[mask], y[mask], degree)
-        return {"coeffs": coeffs, "degree": degree}
-    except Exception:
-        # Fallback to linear
-        try:
-            coeffs = np.polyfit(x[mask], y[mask], 1)
-            return {"coeffs": coeffs, "degree": 1}
-        except Exception:
-            # Ultimate fallback
-            return {"coeffs": [np.nanmean(y)], "degree": 0}
-
-
-def _polynomial_pred_fn(params: dict, x_grid: np.ndarray) -> np.ndarray:
-    """Predict using polynomial fit."""
-    return np.polyval(params["coeffs"], x_grid)
-
-
-def generate_term_structure_confidence_bands(
-    T: np.ndarray,
-    atm_vol: np.ndarray,
-    level: float = 0.68,
-    n_boot: int = 100,
-    fit_degree: int = 2,
-    grid_points: int = 50,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Generate confidence bands for ATM term structure using bootstrap.
-    
-    Parameters:
-    -----------
-    T : np.ndarray
-        Time to expiry values (years)
-    atm_vol : np.ndarray
-        ATM volatility values
-    level : float
-        Confidence level (0.68 for ~1 sigma)
-    n_boot : int
-        Number of bootstrap samples
-    fit_degree : int
-        Polynomial degree for fitting
-    grid_points : int
-        Number of points in interpolation grid
-        
-    Returns:
-    --------
-    tuple[np.ndarray, np.ndarray, np.ndarray]
-        (grid_T, lower_bound, upper_bound)
-    """
-    T = np.asarray(T, dtype=float)
-    atm_vol = np.asarray(atm_vol, dtype=float)
-    
-    # Remove NaN values
-    mask = np.isfinite(T) & np.isfinite(atm_vol)
-    if np.sum(mask) < 3:
-        # Not enough data for meaningful confidence bands
-        return np.array([]), np.array([]), np.array([])
-    
-    T_clean = T[mask]
-    vol_clean = atm_vol[mask]
-    
-    # Create grid for interpolation
-    T_min, T_max = T_clean.min(), T_clean.max()
-    T_grid = np.linspace(T_min, T_max, grid_points)
-    
-    # Generate bootstrap confidence bands
-    try:
-        bands = bootstrap_bands(
-            x=T_clean,
-            y=vol_clean,
-            fit_fn=lambda x, y: _polynomial_fit_fn(x, y, degree=fit_degree),
-            pred_fn=_polynomial_pred_fn,
-            grid=T_grid,
-            level=level,
-            n_boot=n_boot,
-        )
-        return T_grid, bands.lo, bands.hi
-    except Exception:
-        # Fallback: no confidence bands
-        return np.array([]), np.array([]), np.array([])
+from analysis.confidence_bands import Bands
 
 
 def plot_atm_term_structure(
@@ -116,9 +15,6 @@ def plot_atm_term_structure(
     connect: bool = True,
     smooth: bool = False,
     show_ci: bool = False,    # draw CI bars if present
-    ci_level: float = 0.68,   # confidence level for bands
-    generate_ci: bool = True, # automatically generate CI if not present
-    n_boot: int = 100,        # bootstrap samples for CI generation
 ) -> None:
     if atm_df is None or atm_df.empty:
         ax.text(0.5, 0.5, "No ATM data", ha="center", va="center")
@@ -134,41 +30,15 @@ def plot_atm_term_structure(
         x_plot = x
         x_label = "Time to Expiry (years)"
 
-    # Handle confidence intervals
-    ci_rendered = False
-    if show_ci:
-        # First try to use pre-computed confidence intervals
-        if {"atm_lo","atm_hi"}.issubset(atm_df.columns):
-            y_lo = atm_df["atm_lo"].to_numpy(float)
-            y_hi = atm_df["atm_hi"].to_numpy(float)
-            if np.isfinite(y_lo).any() and np.isfinite(y_hi).any():
-                yerr = np.vstack([np.clip(y - y_lo, 0, None), np.clip(y_hi - y, 0, None)])
-                ax.errorbar(x_plot, y, yerr=yerr, fmt="o", ms=4.5, capsize=3, alpha=0.9, label="ATM (fit) ± CI")
-                ci_rendered = True
-        
-        # If no pre-computed CI and generate_ci is True, generate them
-        if not ci_rendered and generate_ci and len(x) >= 3:
-            try:
-                T_grid, ci_lo, ci_hi = generate_term_structure_confidence_bands(
-                    T=x, atm_vol=y, level=ci_level, n_boot=n_boot
-                )
-                
-                if len(T_grid) > 0:
-                    # Convert to plot units
-                    if x_units == "days":
-                        T_grid_plot = T_grid * 365.25
-                    else:
-                        T_grid_plot = T_grid
-                    
-                    # Plot confidence band as filled area
-                    ax.fill_between(T_grid_plot, ci_lo, ci_hi, alpha=0.2, label=f"CI ({ci_level:.0%})")
-                    ax.scatter(x_plot, y, s=30, alpha=0.9, label="ATM (fit)")
-                    ci_rendered = True
-            except Exception as e:
-                print(f"Failed to generate confidence bands: {e}")
-    
-    # Fallback: simple scatter plot
-    if not ci_rendered:
+    if show_ci and {"atm_lo","atm_hi"}.issubset(atm_df.columns):
+        y_lo = atm_df["atm_lo"].to_numpy(float)
+        y_hi = atm_df["atm_hi"].to_numpy(float)
+        if np.isfinite(y_lo).any() and np.isfinite(y_hi).any():
+            yerr = np.vstack([np.clip(y - y_lo, 0, None), np.clip(y_hi - y, 0, None)])
+            ax.errorbar(x_plot, y, yerr=yerr, fmt="o", ms=4.5, capsize=3, alpha=0.9, label="ATM (fit) ± CI")
+        else:
+            ax.scatter(x_plot, y, s=30, alpha=0.9, label="ATM (fit)")
+    else:
         ax.scatter(x_plot, y, s=30, alpha=0.9, label="ATM (fit)")
 
     if connect and len(x_plot) > 1:
@@ -190,29 +60,16 @@ def plot_atm_term_structure(
     ax.set_ylabel("Implied Vol (ATM)")
     ax.legend(loc="best", fontsize=8)
 
-
 def plot_synthetic_etf_term_structure(
     ax: plt.Axes,
-    atm_data: Dict[str, np.ndarray],
-    weights: Dict[str, float],
-    pillar_days: np.ndarray,
+    bands: Bands,
     *,
-    level: float = 0.68,
-    n_boot: int = 200,
     label: str = "Synthetic ATM",
     line_kwargs: Optional[Dict] = None,
 ) -> Bands:
-    """Plot synthetic ETF ATM term structure with confidence bands."""
+    """Plot synthetic ETF ATM term structure using pre-computed bands."""
 
-    bands = synthetic_etf_pillar_bands(
-        atm_data=atm_data,
-        weights=weights,
-        pillar_days=np.asarray(pillar_days, float),
-        level=level,
-        n_boot=n_boot,
-    )
-
-    ax.fill_between(bands.x, bands.lo, bands.hi, alpha=0.20, label=f"CI ({int(level*100)}%)")
+    ax.fill_between(bands.x, bands.lo, bands.hi, alpha=0.20, label=f"CI ({int(bands.level*100)}%)")
 
     line_kwargs = dict(line_kwargs or {})
     line_kwargs.setdefault("lw", 1.8)
@@ -220,7 +77,6 @@ def plot_synthetic_etf_term_structure(
 
     ax.set_xlabel("Pillar (days)")
     ax.set_ylabel("Implied Vol (ATM)")
-    # Refresh legend to ensure synthetic term structure is visible
     handles, labels = ax.get_legend_handles_labels()
     if handles and labels:
         ax.legend(handles, labels, loc="best", fontsize=8)

--- a/tests/test_ci_fix.py
+++ b/tests/test_ci_fix.py
@@ -14,6 +14,8 @@ from analysis.analysis_pipeline import get_smile_slice, available_dates
 from analysis.pillars import compute_atm_by_expiry
 from display.plotting.smile_plot import fit_and_plot_smile
 from display.plotting.term_plot import plot_atm_term_structure
+from volModel.sviFit import fit_svi_slice
+from analysis.confidence_bands import svi_confidence_bands
 
 def test_confidence_intervals():
     """Test that confidence intervals are enabled by default."""
@@ -70,12 +72,17 @@ def test_confidence_intervals():
             
             print(f"   Testing expiry T={T_val:.4f}, S={S:.2f}, {len(K)} options")
             
-            # Plot with CI (should be enabled by default now)
+            # Plot with CI using pre-computed parameters
             fig, ax = plt.subplots(figsize=(8, 6))
+            params = fit_svi_slice(S, K, T_val, iv)
+            m_grid = np.linspace(0.8, 1.2, 121)
+            K_grid = m_grid * S
+            bands = svi_confidence_bands(S, K, T_val, iv, K_grid, level=0.68, n_boot=200)
             result = fit_and_plot_smile(
-                ax, S, K, T_val, iv, 
+                ax, S, K, T_val, iv,
                 model="svi",
-                # ci_level should default to 0.68 now
+                params=params,
+                bands=bands,
             )
             ax.set_title(f"SPY Smile (T={T_val:.4f}, {asof})")
             plt.savefig("test_smile_ci.png", dpi=100, bbox_inches='tight')

--- a/tests/test_synthetic_etf_plotting.py
+++ b/tests/test_synthetic_etf_plotting.py
@@ -12,6 +12,10 @@ from display.plotting.display_viewers_synthetic_etf_viewer import (
 
 from display.plotting.smile_plot import plot_synthetic_etf_smile
 from display.plotting.term_plot import plot_synthetic_etf_term_structure
+from analysis.confidence_bands import (
+    synthetic_etf_confidence_bands,
+    synthetic_etf_pillar_bands,
+)
 
 def test_plot_synthetic_etf_smile_runs():
     surfaces = {
@@ -22,7 +26,8 @@ def test_plot_synthetic_etf_smile_runs():
     grid = np.array([0.9, 1.0, 1.1])
 
     fig, ax = plt.subplots()
-    bands = plot_synthetic_etf_smile(ax, surfaces, weights, grid, n_boot=5)
+    bands = synthetic_etf_confidence_bands(surfaces, weights, grid, n_boot=5)
+    bands = plot_synthetic_etf_smile(ax, bands)
     assert bands.mean.shape == grid.shape
     plt.close(fig)
 
@@ -37,7 +42,8 @@ def test_plot_synthetic_etf_smile_adds_to_legend():
     ax.plot(grid, surfaces['A'], label='Target')
     ax.legend()
 
-    plot_synthetic_etf_smile(ax, surfaces, weights, grid, n_boot=5)
+    bands = synthetic_etf_confidence_bands(surfaces, weights, grid, n_boot=5)
+    plot_synthetic_etf_smile(ax, bands)
     legend = ax.get_legend()
     assert legend is not None
     labels = [text.get_text() for text in legend.get_texts()]
@@ -53,7 +59,8 @@ def test_plot_synthetic_etf_term_structure_runs():
     pillar_days = np.array([30, 60, 90])
 
     fig, ax = plt.subplots()
-    bands = plot_synthetic_etf_term_structure(ax, atm_data, weights, pillar_days, n_boot=5)
+    bands = synthetic_etf_pillar_bands(atm_data, weights, pillar_days, n_boot=5)
+    bands = plot_synthetic_etf_term_structure(ax, bands)
     assert bands.mean.shape == pillar_days.shape
     plt.close(fig)
 
@@ -69,7 +76,8 @@ def test_plot_synthetic_etf_term_structure_adds_to_legend():
     ax.plot(pillar_days, atm_data['A'], label='Target')
     ax.legend()
 
-    plot_synthetic_etf_term_structure(ax, atm_data, weights, pillar_days, n_boot=5)
+    bands = synthetic_etf_pillar_bands(atm_data, weights, pillar_days, n_boot=5)
+    plot_synthetic_etf_term_structure(ax, bands)
     legend = ax.get_legend()
     assert legend is not None
     labels = [text.get_text() for text in legend.get_texts()]

--- a/tests/test_tps_plotting.py
+++ b/tests/test_tps_plotting.py
@@ -1,0 +1,34 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+from volModel.polyFit import fit_tps_slice
+from analysis.confidence_bands import tps_confidence_bands
+from display.plotting.smile_plot import fit_and_plot_smile
+
+
+def test_tps_smile_plot_runs():
+    S = 100.0
+    K = S * np.array([0.9, 1.0, 1.1, 1.2])
+    T = 0.5
+    log_mny = np.log(K / S)
+    iv = 0.2 + 0.05 * log_mny ** 2
+    params = fit_tps_slice(S, K, T, iv)
+    grid = np.linspace(0.8, 1.2, 21) * S
+    bands = tps_confidence_bands(S, K, T, iv, grid, n_boot=5)
+    fig, ax = plt.subplots()
+    result = fit_and_plot_smile(
+        ax,
+        S=S,
+        K=K,
+        T=T,
+        iv=iv,
+        model="tps",
+        params=params,
+        bands=bands,
+    )
+    assert result["params"]
+    assert bands.mean.shape == grid.shape
+    plt.close(fig)
+


### PR DESCRIPTION
## Summary
- Add TPS smile fitter and bands alongside SVI/SABR
- Extend plotting and analysis pipeline to use precomputed TPS params
- Cover TPS plotting via new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7156a673c8333969e4d863220e189