### PR TITLE
Build synthetic surfaces regardless of overlay flag

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -750,8 +750,9 @@ def prepare_smile_data(
 ) -> Dict[str, Any]:
     """Precompute smile data and fitted parameters for plotting.
 
-    Returns a dictionary with raw quote arrays, optional prebuilt surfaces,
-    peer slices, and a ``fit_info`` mapping suitable for parameter summaries.
+    Returns a dictionary with raw quote arrays, prebuilt target and synthetic
+    surfaces when peers are supplied, peer slices, and a ``fit_info`` mapping
+    suitable for parameter summaries.
     """
     peers = list(peers or [])
 
@@ -887,7 +888,7 @@ def prepare_smile_data(
 
     tgt_surface = None
     syn_surface = None
-    if overlay_synth and peers:
+    if peers:
         try:
             tickers = list({target, *peers})
             surfaces = build_surface_grids(
@@ -898,8 +899,8 @@ def prepare_smile_data(
             if target in surfaces and asof in surfaces[target]:
                 tgt_surface = surfaces[target][asof]
             peer_surfaces = {p: surfaces[p] for p in peers if p in surfaces}
-            if weights:
-                w = dict(weights)
+            if peer_surfaces:
+                w = {p: float(weights.get(p, 1.0)) for p in peer_surfaces} if weights else {p: 1.0 for p in peer_surfaces}
                 synth_by_date = combine_surfaces(peer_surfaces, w)
                 syn_surface = synth_by_date.get(asof)
         except Exception:
@@ -943,10 +944,11 @@ def prepare_term_data(
     atm_band: float = 0.05,
     max_expiries: int = 6,
 ) -> Dict[str, Any]:
-    """Precompute ATM term structure and optional synthetic overlay.
+    """Precompute ATM term structure and synthetic overlay data.
 
-    Returns a dictionary with ``atm_curve`` and (if requested) ``synth_curve``
-    DataFrames ready for plotting.
+    Returns a dictionary with ``atm_curve`` and ``synth_curve`` DataFrames ready
+    for plotting. When peers are supplied, the synthetic curve is always
+    constructed, regardless of whether it will be rendered.
     """
 
     df_all = get_smile_slice(target, asof, T_target_years=None, max_expiries=max_expiries)
@@ -965,7 +967,7 @@ def prepare_term_data(
     )
 
     synth_curve = None
-    if overlay_synth and peers:
+    if peers:
         w = pd.Series(weights if weights else {p: 1.0 for p in peers}, dtype=float)
         if w.sum() <= 0:
             w = pd.Series({p: 1.0 for p in peers}, dtype=float)

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -227,7 +227,7 @@ class PlotManager:
             self._clear_correlation_colorbar(ax)
 
             weights = None
-            if overlay_synth and peers:
+            if peers:
                 weights = self._weights_from_ui_or_matrix(
                     target, peers, weight_mode, asof=asof, pillars=self.last_corr_meta.get("pillars") if self.last_corr_meta else None
                 )
@@ -278,7 +278,7 @@ class PlotManager:
             self._clear_correlation_colorbar(ax)
 
             weights = None
-            if overlay_synth and peers:
+            if peers:
                 weights = self._weights_from_ui_or_matrix(
                     target,
                     peers,


### PR DESCRIPTION
## Summary
- Generate target and synthetic surfaces in `prepare_smile_data` whenever peers are provided, independent of overlay display.
- Always compute synthetic term structures in `prepare_term_data` when peers exist.
- Collect peer weights in the GUI manager even when the synthetic overlay is disabled.

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_db_logger' from 'project_logging.db_logger')*


------
https://chatgpt.com/codex/tasks/task_e_68a7320f64dc8333a5cb5e884d84e231