### PR TITLE
Fix ATM term structure plot numeric handling

### DIFF
--- a/display/plotting/term_plot.py
+++ b/display/plotting/term_plot.py
@@ -20,8 +20,8 @@ def plot_atm_term_structure(
         ax.text(0.5, 0.5, "No ATM data", ha="center", va="center")
         return
 
-    x = atm_df["T"].to_numpy()
-    y = atm_df["atm_vol"].to_numpy()
+    x = atm_df["T"].to_numpy(float)
+    y = atm_df["atm_vol"].to_numpy(float)
 
     if x_units == "days":
         x_plot = x * 365.25

--- a/tests/test_term_plot.py
+++ b/tests/test_term_plot.py
@@ -1,0 +1,19 @@
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from display.plotting.term_plot import plot_atm_term_structure
+
+
+def test_plot_atm_term_structure_handles_string_vols():
+    atm_curve = pd.DataFrame({
+        'T': [0.5, 1.0, 1.5],
+        'atm_vol': ['0.2', '0.3', '0.4'],
+    })
+    fig, ax = plt.subplots()
+    plot_atm_term_structure(ax, atm_curve)
+    offsets = ax.collections[0].get_offsets()
+    assert np.allclose(offsets[:, 1], [0.2, 0.3, 0.4])
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- cast term structure T and atm_vol columns to float before plotting to avoid categorical flattening
- add regression test ensuring string ATM vols render correctly

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_db_logger')*
- `pytest tests/test_term_plot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73aac17d88333b5fe7a35b7785350