### PR TITLE
Add calc cache staleness check and cleanup script

### DIFF
--- a/analysis/cache_io.py
+++ b/analysis/cache_io.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+import sqlite3
+import json
+import time
+from typing import Any, Optional
+
+# Increment this whenever the structure of cached artifacts changes
+ARTIFACT_VERSION = 2
+
+CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS calc_cache (
+    cache_key TEXT PRIMARY KEY,
+    artifact_version INTEGER NOT NULL,
+    payload TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL
+);
+"""
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the calc_cache table exists."""
+    conn.execute(CREATE_SQL)
+    conn.commit()
+
+
+def get_latest_raw_timestamp(conn: sqlite3.Connection) -> int:
+    """Return the latest timestamp from raw option tables.
+
+    This checks both options_quotes and underlying_prices tables. If the
+    tables are empty, 0 is returned.
+    """
+    q = """
+    SELECT MAX(ts) FROM (
+        SELECT MAX(strftime('%s', asof_date)) AS ts FROM options_quotes
+        UNION ALL
+        SELECT MAX(strftime('%s', asof_date)) AS ts FROM underlying_prices
+    )
+    """
+    cur = conn.execute(q)
+    val = cur.fetchone()[0]
+    return int(val) if val is not None else 0
+
+
+def load_calc_cache(
+    conn: sqlite3.Connection,
+    cache_key: str,
+    latest_raw_ts: Optional[int] = None,
+) -> Optional[Any]:
+    """Load cached payload if still valid.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection.
+    cache_key : str
+        Lookup key for the cached artifact.
+    latest_raw_ts : int, optional
+        Latest timestamp from raw option tables. If not provided it will be
+        computed automatically.
+    """
+    ensure_table(conn)
+    cur = conn.execute(
+        "SELECT payload, created_at, expires_at, artifact_version FROM calc_cache WHERE cache_key=?",
+        (cache_key,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+    payload, created_at, expires_at, version = row
+    now = int(time.time())
+    if expires_at < now or version != ARTIFACT_VERSION:
+        return None
+    if latest_raw_ts is None:
+        latest_raw_ts = get_latest_raw_timestamp(conn)
+    if latest_raw_ts > created_at:
+        # Raw data updated after this artifact was created
+        return None
+    return json.loads(payload)
+
+
+def save_calc_cache(
+    conn: sqlite3.Connection,
+    cache_key: str,
+    payload: Any,
+    ttl_seconds: int = 86400,
+) -> None:
+    """Persist payload into calc_cache with a TTL."""
+    ensure_table(conn)
+    now = int(time.time())
+    expires_at = now + ttl_seconds
+    conn.execute(
+        "REPLACE INTO calc_cache(cache_key, artifact_version, payload, created_at, expires_at) VALUES (?,?,?,?,?)",
+        (cache_key, ARTIFACT_VERSION, json.dumps(payload), now, expires_at),
+    )
+    conn.commit()

--- a/scripts/cleanup_calc_cache.py
+++ b/scripts/cleanup_calc_cache.py
@@ -1,0 +1,30 @@
+"""Remove expired rows from the calc_cache table.
+
+This script can be scheduled via cron to keep the cache table small.
+Example cron entry to run nightly at 2am:
+    0 2 * * * /usr/bin/python path/to/cleanup_calc_cache.py --db-path=/path/db.db
+"""
+from __future__ import annotations
+import argparse
+import sqlite3
+
+SQL = "DELETE FROM calc_cache WHERE expires_at < strftime('%s','now')"
+
+
+def cleanup(db_path: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(SQL)
+        conn.commit()
+        return cur.rowcount
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Cleanup expired calc_cache rows")
+    parser.add_argument("--db-path", default="data/iv_data.db", help="Path to SQLite database")
+    args = parser.parse_args()
+    removed = cleanup(args.db_path)
+    print(f"Removed {removed} expired rows from calc_cache")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cache_io.py
+++ b/tests/test_cache_io.py
@@ -1,0 +1,33 @@
+import sqlite3
+from analysis.cache_io import save_calc_cache, load_calc_cache
+
+
+def _setup_db():
+    conn = sqlite3.connect(':memory:')
+    conn.executescript(
+        """
+        CREATE TABLE options_quotes(asof_date TEXT);
+        CREATE TABLE underlying_prices(asof_date TEXT);
+        """
+    )
+    return conn
+
+
+def test_cache_reuse_when_raw_unchanged():
+    conn = _setup_db()
+    conn.execute("INSERT INTO options_quotes(asof_date) VALUES('2000-01-01')")
+    save_calc_cache(conn, 'k', {'v': 1})
+    loaded = load_calc_cache(conn, 'k')
+    assert loaded == {'v': 1}
+
+
+def test_cache_invalidated_on_raw_update():
+    conn = _setup_db()
+    conn.execute("INSERT INTO options_quotes(asof_date) VALUES('1999-01-01')")
+    save_calc_cache(conn, 'k', {'v': 1})
+    # Force created_at to be old
+    conn.execute("UPDATE calc_cache SET created_at = 0")
+    # Later raw data arrives
+    conn.execute("INSERT INTO options_quotes(asof_date) VALUES('2000-01-01')")
+    conn.commit()
+    assert load_calc_cache(conn, 'k') is None


### PR DESCRIPTION
## Summary
- add `analysis/cache_io.py` with versioned calc_cache helpers and raw data freshness check
- include script to purge expired cache rows
- test cache invalidation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74416613c8333bcab592f687abe08