### PR TITLE
Add pooled vs isolated experiment using existing utilities

### DIFF
--- a/analysis/experiments/__init__.py
+++ b/analysis/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Experiments for exploring modeling strategies."""

--- a/analysis/experiments/pooled_vs_isolated.py
+++ b/analysis/experiments/pooled_vs_isolated.py
@@ -1,0 +1,63 @@
+"""Experiment comparing pooled vs isolated modeling.
+
+This module leverages existing modeling and evaluation utilities
+from the analysis package.  Individual surfaces are built using
+:func:`analysis.syntheticETFBuilder.build_surface_grids` and
+combined via :func:`analysis.syntheticETFBuilder.combine_surfaces`.
+The resulting surfaces are evaluated with
+:func:`analysis.correlation_utils.compute_atm_corr`.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence, Tuple, Dict
+import pandas as pd
+
+from analysis.syntheticETFBuilder import build_surface_grids, combine_surfaces
+from analysis.correlation_utils import compute_atm_corr
+
+
+def run_experiment(
+    tickers: Iterable[str],
+    weights: Mapping[str, float],
+    asof: str,
+    pillars_days: Sequence[int] = (7, 30, 60, 90),
+) -> Tuple[Dict[pd.Timestamp, pd.DataFrame], pd.DataFrame, pd.DataFrame]:
+    """Run the pooled-vs-isolated experiment.
+
+    Parameters
+    ----------
+    tickers:
+        Collection of tickers to model.
+    weights:
+        Mapping of ticker -> weight used when pooling surfaces.
+    asof:
+        As-of date for evaluation.
+    pillars_days:
+        Pillar days used for ATM correlation evaluation.
+
+    Returns
+    -------
+    pooled_surface:
+        Synthetic surface created by pooling peer surfaces with ``weights``.
+    atm_df:
+        ATM pillar matrix used for evaluation.
+    corr_df:
+        Correlation matrix across tickers for the specified pillars.
+    """
+
+    # --- Modeling: build individual surfaces with existing utilities ---
+    surfaces = build_surface_grids(tickers=tickers)
+
+    peer_surfaces = {t: surfaces.get(t, {}) for t in weights.keys()}
+    pooled_surface = combine_surfaces(peer_surfaces, weights)
+
+    # --- Evaluation: compute ATM correlations using existing helper ---
+    atm_df, corr_df = compute_atm_corr(
+        get_smile_slice=lambda ticker, asof, T_target_years=None: peer_surfaces.get(ticker, {}).get(asof),
+        tickers=list(weights.keys()),
+        asof=asof,
+        pillars_days=pillars_days,
+    )
+
+    return pooled_surface, atm_df, corr_df

--- a/tests/test_pooled_vs_isolated_experiment.py
+++ b/tests/test_pooled_vs_isolated_experiment.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+from analysis.experiments.pooled_vs_isolated import run_experiment
+
+
+def test_experiment_uses_model_and_eval(monkeypatch):
+    calls = {"build": False, "combine": False, "corr": False}
+
+    def fake_build_surface_grids(tickers, **kwargs):
+        calls["build"] = True
+        return {
+            t: {"2024-01-01": pd.DataFrame({"mny": [1.0], "iv": [0.2]})}
+            for t in tickers
+        }
+
+    def fake_combine_surfaces(surfaces, weights):
+        calls["combine"] = True
+        return {"2024-01-01": pd.DataFrame({"mny": [1.0], "iv": [0.2]})}
+
+    def fake_compute_atm_corr(get_smile_slice, tickers, asof, pillars_days, **kwargs):
+        calls["corr"] = True
+        return pd.DataFrame(), pd.DataFrame()
+
+    monkeypatch.setattr(
+        "analysis.experiments.pooled_vs_isolated.build_surface_grids",
+        fake_build_surface_grids,
+    )
+    monkeypatch.setattr(
+        "analysis.experiments.pooled_vs_isolated.combine_surfaces",
+        fake_combine_surfaces,
+    )
+    monkeypatch.setattr(
+        "analysis.experiments.pooled_vs_isolated.compute_atm_corr",
+        fake_compute_atm_corr,
+    )
+
+    run_experiment(tickers=["A", "B"], weights={"A": 0.5, "B": 0.5}, asof="2024-01-01")
+
+    assert all(calls.values())


### PR DESCRIPTION
## Summary
- add `analysis.experiments.pooled_vs_isolated` to model surfaces and evaluate ATM correlations
- include unit test ensuring experiment leverages existing surface-building and correlation utilities

## Testing
- `pytest tests/test_pooled_vs_isolated_experiment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74705b5088333bee7462ba0d559a6