### PR TITLE
Add spillover caching and warmup

### DIFF
--- a/analysis/cache.py
+++ b/analysis/cache.py
@@ -1,0 +1,51 @@
+import os
+import json
+import pickle
+import hashlib
+import sqlite3
+from typing import Any, Callable
+
+
+def compute_or_load(kind: str, payload: dict, builder: Callable[[], Any], db_path: str) -> Any:
+    """Compute a result or load it from an on-disk cache.
+
+    Parameters
+    ----------
+    kind: str
+        Logical name for the calculation (used to namespace cache keys).
+    payload: dict
+        Hashable parameters defining the calculation.
+    builder: Callable[[], Any]
+        Function that performs the computation when a cache miss occurs.
+    db_path: str
+        Path to the SQLite database used for storing cached results.
+    """
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    payload_json = json.dumps(payload, sort_keys=True)
+    key = hashlib.sha256(payload_json.encode()).hexdigest()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS calculations (
+                kind TEXT NOT NULL,
+                key TEXT NOT NULL,
+                payload TEXT,
+                result BLOB,
+                PRIMARY KEY(kind, key)
+            )
+            """
+        )
+        cur = conn.execute(
+            "SELECT result FROM calculations WHERE kind=? AND key= ?",
+            (kind, key),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return pickle.loads(row[0])
+        result = builder()
+        conn.execute(
+            "INSERT INTO calculations(kind, key, payload, result) VALUES (?,?,?,?)",
+            (kind, key, payload_json, pickle.dumps(result)),
+        )
+        conn.commit()
+        return result

--- a/display/gui/browser.py
+++ b/display/gui/browser.py
@@ -123,6 +123,8 @@ class BrowserApp(tk.Tk):
 
         self.spill_win = None
 
+        self.notebook.bind("<<NotebookTabChanged>>", self._on_tab_change)
+
     # ---------- events ----------
     def _on_target_change(self, *_):
         """
@@ -178,6 +180,13 @@ class BrowserApp(tk.Tk):
             self.after(0, update_ui)
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _on_tab_change(self, event):
+        if event.widget.select() == str(self.tab_spillover):
+            tickers = [self.inputs.get_target()] + self.inputs.get_peers()
+            tickers = [t for t in tickers if t]
+            if tickers:
+                self.tab_spillover.warmup(tickers)
 
     def _on_download(self):
         """

--- a/display/gui/spillover_gui.py
+++ b/display/gui/spillover_gui.py
@@ -10,6 +10,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from analysis.spillover.vol_spillover import run_spillover, load_iv_data
+from analysis.cache import compute_or_load
+import threading
 
 
 class SpilloverFrame(ttk.Frame):
@@ -90,16 +92,78 @@ class SpilloverFrame(ttk.Frame):
             messagebox.showerror("Data missing", f"Cannot find {iv_path}")
             return
         df = load_iv_data(str(iv_path), use_raw=self.var_raw.get())
-        self.results = run_spillover(
-            df,
-            tickers=tickers,
-            threshold=thr,
-            lookback=lookback,
-            top_k=topk,
-            horizons=horizons,
+        payload = {
+            "tickers": sorted(tickers),
+            "threshold": thr,
+            "lookback": lookback,
+            "top_k": topk,
+            "horizons": tuple(horizons),
+            "asof": df["date"].max().floor("min").isoformat(),
+        }
+
+        def _builder():
+            return run_spillover(
+                df,
+                tickers=tickers,
+                threshold=thr,
+                lookback=lookback,
+                top_k=topk,
+                horizons=horizons,
+            )
+
+        self.results = compute_or_load(
+            "spill", payload, _builder, "data/calculations.db"
         )
         self._populate_events()
         self._plot_response()
+
+    def warmup(self, tickers=None):
+        if tickers is None:
+            tickers = [
+                t.strip().upper()
+                for t in self.ent_tickers.get().split(",")
+                if t.strip()
+            ]
+        if not tickers:
+            return
+        try:
+            lookback = int(self.ent_lookback.get())
+            thr = float(self.ent_threshold.get()) / 100.0
+            topk = int(self.ent_topk.get())
+            horizons = [
+                int(h) for h in self.ent_horizons.get().split(",") if h
+            ]
+        except ValueError:
+            return
+        iv_path = ROOT / "data" / "iv_daily.parquet"
+        if not iv_path.exists():
+            return
+        df = load_iv_data(str(iv_path), use_raw=self.var_raw.get())
+        payload = {
+            "tickers": sorted(tickers),
+            "threshold": thr,
+            "lookback": lookback,
+            "top_k": topk,
+            "horizons": tuple(horizons),
+            "asof": df["date"].max().floor("min").isoformat(),
+        }
+
+        def _builder():
+            return run_spillover(
+                df,
+                tickers=tickers,
+                threshold=thr,
+                lookback=lookback,
+                top_k=topk,
+                horizons=horizons,
+            )
+
+        threading.Thread(
+            target=lambda: compute_or_load(
+                "spill", payload, _builder, "data/calculations.db"
+            ),
+            daemon=True,
+        ).start()
 
     def _populate_events(self):
         for i in self.tree.get_children():


### PR DESCRIPTION
## Summary
- cache spillover computations with `compute_or_load`
- support background warmups for spillover tab
- add warm cache helper in analysis/cache.py

## Testing
- `pytest` *(fails: KeyboardInterrupt after 8 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a74412c3e083339aca8b9559a42925