### PR TITLE
Fit polynomial model for term structure plot

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -337,6 +337,7 @@ class PlotManager:
                 "weights": weights.to_dict() if weights is not None else None,
                 "atm_band": atm_band,
                 "max_expiries": max_expiries,
+                "weight_mode": weight_mode,
             }
 
             def _builder():
@@ -1074,11 +1075,8 @@ class PlotManager:
             ax,
             atm_curve,
             x_units=x_units,
-            connect=True,
-            smooth=True,
-
+            fit=True,
             show_ci=bool(ci and ci > 0 and {"ci_lo", "ci_hi"}.issubset(atm_curve.columns)),
- 
         )
         title = f"{target}  {asof}  ATM Term Structure  (N={len(atm_curve)})"
         synth_bands = data.get("synth_bands")

--- a/tests/test_term_weight_mode_replot.py
+++ b/tests/test_term_weight_mode_replot.py
@@ -1,0 +1,53 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from display.gui.gui_plot_manager import PlotManager
+
+
+def test_term_replots_when_weight_method_changes(monkeypatch):
+    pm = PlotManager()
+
+    # Ensure weights function returns constant weights regardless of mode
+    monkeypatch.setattr(
+        pm,
+        "_weights_from_ui_or_matrix",
+        lambda target, peers, weight_mode, **kwargs: pd.Series({peers[0]: 1.0})
+    )
+
+    payloads = []
+
+    def fake_compute_or_load(name, payload, builder, **kwargs):
+        payloads.append(payload)
+        # minimal valid return structure for _plot_term
+        return {"atm_curve": pd.DataFrame({"T": [0.1], "atm_vol": [0.2]}), "synth_bands": None}
+
+    monkeypatch.setattr(
+        "display.gui.gui_plot_manager.compute_or_load", fake_compute_or_load
+    )
+
+    fig, ax = plt.subplots()
+    settings = {
+        "plot_type": "Term",
+        "target": "TGT",
+        "asof": "2024-01-01",
+        "model": "svi",
+        "T_days": 30,
+        "ci": 68,
+        "x_units": "years",
+        "overlay_synth": False,
+        "peers": ["AAA"],
+        "pillars": [30],
+        "weight_method": "corr",
+        "feature_mode": "iv_atm",
+        "max_expiries": 6,
+    }
+
+    pm.plot(ax, settings)
+    settings["weight_method"] = "equal"
+    pm.plot(ax, settings)
+
+    assert len(payloads) == 2
+    modes = [p.get("weight_mode") for p in payloads]
+    assert modes[0] != modes[1]

--- a/tests/test_volmodel_imports.py
+++ b/tests/test_volmodel_imports.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+
+def test_termfit_exposes_sabr_and_svi():
+    # Ensure top-level volModel exports include sabr, svi, and term fitting
+    from volModel import (
+        fit_term_structure,
+        fit_sabr_slice,
+        fit_svi_slice,
+    )
+
+    # simple polynomial term fit
+    T = np.array([0.1, 0.2, 0.3])
+    iv = np.array([0.2, 0.21, 0.22])
+    params = fit_term_structure(T, iv)
+    assert "coeff" in params
+
+    # smoke-test sabr and svi fits on tiny synthetic slice
+    S = 100.0
+    Ks = np.array([95.0, 100.0, 105.0])
+    slice_iv = np.array([0.21, 0.2, 0.22])
+
+    sabr_params = fit_sabr_slice(S, Ks, 0.5, slice_iv)
+    assert isinstance(sabr_params, dict)
+
+    svi_params = fit_svi_slice(S, Ks, 0.5, slice_iv)
+    assert isinstance(svi_params, dict)
+

--- a/volModel/__init__.py
+++ b/volModel/__init__.py
@@ -1,5 +1,23 @@
 """
 Volatility Model module for CleanIV_Correlation project.
 
-This module contains volatility model implementations including SABR and SVI fits.
+This module contains volatility model implementations including SABR, SVI,
+polynomial fits, and term-structure utilities.
 """
+
+from .sviFit import fit_svi_slice, svi_smile_iv
+from .sabrFit import fit_sabr_slice, sabr_smile_iv
+from .polyFit import fit_poly, fit_tps_slice, tps_smile_iv
+from .termFit import fit_term_structure, term_structure_iv
+
+__all__ = [
+    "fit_svi_slice",
+    "svi_smile_iv",
+    "fit_sabr_slice",
+    "sabr_smile_iv",
+    "fit_poly",
+    "fit_tps_slice",
+    "tps_smile_iv",
+    "fit_term_structure",
+    "term_structure_iv",
+]

--- a/volModel/termFit.py
+++ b/volModel/termFit.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Simple ATM term structure fitting utilities."""
+
+from typing import Dict
+import numpy as np
+
+__all__ = ["fit_term_structure", "term_structure_iv"]
+
+
+def fit_term_structure(T: np.ndarray, iv: np.ndarray, degree: int = 2) -> Dict[str, np.ndarray]:
+    """Fit a polynomial term structure ``iv = f(T)``.
+
+    Parameters
+    ----------
+    T : array-like
+        Time to expiry in **years**.
+    iv : array-like
+        Implied volatilities at each ``T``.
+    degree : int, optional
+        Polynomial degree, default 2 (quadratic).
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``coeff`` (highest order first), ``rmse`` and ``degree``.
+        If there are insufficient data points the coefficient array will be empty
+        and ``rmse`` will be ``nan``.
+    """
+    T = np.asarray(T, dtype=float)
+    iv = np.asarray(iv, dtype=float)
+    mask = np.isfinite(T) & np.isfinite(iv)
+    T = T[mask]
+    iv = iv[mask]
+    if T.size <= degree:
+        return {"coeff": np.array([]), "rmse": float("nan"), "degree": int(degree)}
+    coeff = np.polyfit(T, iv, int(degree))
+    fit = np.polyval(coeff, T)
+    rmse = float(np.sqrt(np.mean((fit - iv) ** 2)))
+    return {"coeff": coeff, "rmse": rmse, "degree": int(degree)}
+
+
+def term_structure_iv(T: np.ndarray, params: Dict[str, np.ndarray]) -> np.ndarray:
+    """Evaluate fitted polynomial term structure at ``T`` values."""
+    coeff = np.asarray(params.get("coeff", []), dtype=float)
+    if coeff.size == 0:
+        return np.full_like(np.asarray(T, dtype=float), np.nan, dtype=float)
+    return np.polyval(coeff, np.asarray(T, dtype=float))
+


### PR DESCRIPTION
## Summary
- Add polynomial-based term structure fitting utilities.
- Plot ATM term structure using fitted curve instead of raw connected line.
- Update GUI to call the new term plot API.
- Ensure term plot cache keys include weight_mode so changing the weighting method triggers recomputation.
- Add regression test verifying term data reload when weight method changes.
- Expose SABR and SVI fitting helpers alongside term-structure utilities in the `volModel` package.
- Add smoke test confirming top-level `volModel` exports these helpers.

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'save_calc_cache')*
- `pytest tests/test_term_plot.py tests/test_synthetic_etf_plotting.py tests/test_term_weight_mode_replot.py tests/test_volmodel_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7540812488333b35b571156e336f1