### PR TITLE
Show term structure metrics in parameter summary

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -363,6 +363,35 @@ class PlotManager:
             if atm_curve is None or atm_curve.empty:
                 ax.set_title("No data")
                 return
+
+            # Prepare data for parameter summary tab
+            try:
+                fit_map: dict = {}
+                for _, row in atm_curve.iterrows():
+                    T_val = float(row.get("T", np.nan))
+                    if not np.isfinite(T_val):
+                        continue
+                    entry: dict = {}
+                    exp = row.get("expiry")
+                    if pd.notna(exp):
+                        entry["expiry"] = str(exp)
+                    sens = {
+                        k: row[k]
+                        for k in ("atm_vol", "skew", "curv")
+                        if k in row and pd.notna(row[k])
+                    }
+                    if sens:
+                        entry["sens"] = sens
+                    if entry:
+                        fit_map[T_val] = entry
+                self.last_fit_info = {
+                    "ticker": target,
+                    "asof": asof,
+                    "fit_by_expiry": fit_map,
+                }
+            except Exception:
+                self.last_fit_info = None
+
             self._plot_term(
                 ax,
                 data,

--- a/tests/test_plot_manager_term_summary.py
+++ b/tests/test_plot_manager_term_summary.py
@@ -1,0 +1,46 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+from unittest.mock import patch
+
+from display.gui.gui_plot_manager import PlotManager
+
+
+def test_term_plot_populates_last_fit_info():
+    pm = PlotManager()
+    fig, ax = plt.subplots()
+    try:
+        atm_curve = pd.DataFrame({
+            'T': [0.5, 1.0],
+            'atm_vol': [0.2, 0.25],
+            'skew': [0.01, 0.02],
+            'curv': [0.0, -0.01],
+            'expiry': ['2024-06-01', '2024-12-01'],
+        })
+        data = {'atm_curve': atm_curve}
+        with patch('display.gui.gui_plot_manager.compute_or_load', return_value=data):
+            settings = {
+                'plot_type': 'Term ATM',
+                'target': 'XYZ',
+                'asof': '2024-01-01',
+                'model': 'svi',
+                'T_days': 30,
+                'ci': 68,
+                'x_units': 'years',
+                'peers': [],
+                'pillars': [30],
+                'overlay_synth': False,
+                'overlay_peers': False,
+                'max_expiries': 2,
+                'atm_band': 0.05,
+                'weight_method': 'corr',
+                'feature_mode': 'iv_atm',
+            }
+            pm.plot(ax, settings)
+        info = pm.last_fit_info
+        assert info['ticker'] == 'XYZ'
+        assert 0.5 in info['fit_by_expiry']
+        assert info['fit_by_expiry'][0.5]['sens']['atm_vol'] == 0.2
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## Summary
- populate PlotManager.last_fit_info when rendering term structure plots
- add regression test ensuring term plot data flows into parameter summary

## Testing
- `pytest` *(fails: ImportError: cannot import name 'save_calc_cache')*
- `pytest tests/test_plot_manager_term_summary.py tests/test_term_plot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a75486598c8333b61d57f6d5d38647