### PR TITLE
Clarify synthetic ETF labels and rename corr matrix references

### DIFF
--- a/display/gui/gui_input.py
+++ b/display/gui/gui_input.py
@@ -54,7 +54,7 @@ DEFAULT_OVERLAY = False
 PLOT_TYPES = (
     "Smile (K/S vs IV)",
     "Term (ATM vs T)",
-    "Corr Matrix",
+    "Relative Weight Matrix",
     "Synthetic Surface (Smile)",
     "ETF Weights",
 )
@@ -70,7 +70,7 @@ def _derive_feature_scope(plot_type: str, feature_mode: str) -> str:
         return "term"
     if plot_type.startswith("Synthetic Surface"):
         return "surface"
-    if plot_type.startswith("Corr Matrix"):
+    if plot_type.startswith("Relative Weight Matrix"):
         if feature_mode in ("iv_atm", "ul"):
             # decide later based on pillars count
             return "term"
@@ -467,7 +467,7 @@ class InputPanel(ttk.Frame):
             pillars = self.get_pillars()
 
             feature_scope = _derive_feature_scope(plot_type, feature_mode)
-            if plot_type.startswith("Corr Matrix") and feature_mode in ("iv_atm", "ul"):
+            if plot_type.startswith("Relative Weight Matrix") and feature_mode in ("iv_atm", "ul"):
                 feature_scope = "term" if len(pillars) >= 2 else "smile"
 
             self.manager.update(
@@ -503,10 +503,10 @@ class InputPanel(ttk.Frame):
         show_pillars = (
             plot.startswith("Term")
             or plot.startswith("Synthetic Surface")
-            or (plot.startswith("Corr Matrix") and feat.startswith("surface"))
+            or (plot.startswith("Relative Weight Matrix") and feat.startswith("surface"))
         )
 
-        if plot.startswith("Corr Matrix") and feat in ("iv_atm", "ul"):
+        if plot.startswith("Relative Weight Matrix") and feat in ("iv_atm", "ul"):
             show_pillars = len(self.get_pillars()) >= 2
             show_T = not show_pillars
 

--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -406,8 +406,8 @@ class PlotManager:
             )
             return
 
-        # --- Corr Matrix ---
-        elif plot_type.startswith("Corr Matrix"):
+        # --- Relative Weight Matrix ---
+        elif plot_type.startswith("Relative Weight Matrix"):
             self._plot_corr_matrix(ax, target, peers, asof, pillars, weight_mode, atm_band)
             return
 
@@ -474,7 +474,7 @@ class PlotManager:
         (target, peers, weight_mode=..., asof=..., pillar_days=...)
         positional: (target, peers, mode, asof, pillar_days)
 
-        Fallbacks to corr-matrix-derived weights (if cached meta matches) then equal weights.
+        Fallbacks to relative weight matrix-derived weights (if cached meta matches) then equal weights.
         """
         import numpy as np
         import pandas as pd
@@ -715,8 +715,17 @@ class PlotManager:
                         # Filter final valid data before plotting
                         final_valid = np.isfinite(x_mny) & np.isfinite(y_syn)
                         if np.sum(final_valid) >= 2:
+                            mode_lbl = (weight_mode.split("_")[0] if weight_mode else "")
+                            if mode_lbl == "corr":
+                                mode_lbl = "relative weight matrix"
+                            syn_label = f"Synthetic ETF smile ({mode_lbl})" if mode_lbl else "Synthetic ETF smile"
                             ax.plot(
-                                x_mny[final_valid], y_syn[final_valid], "--", linewidth=1.6, alpha=0.95, label="Synthetic smile (corr-matrix)"
+                                x_mny[final_valid],
+                                y_syn[final_valid],
+                                "--",
+                                linewidth=1.6,
+                                alpha=0.95,
+                                label=syn_label,
                             )
                         ax.legend(loc="best", fontsize=8)
             except Exception:
@@ -814,8 +823,24 @@ class PlotManager:
             # Filter final valid data before plotting
             final_valid = np.isfinite(x_mny) & np.isfinite(y_tgt) & np.isfinite(y_syn)
             if np.sum(final_valid) >= 2:
-                ax.plot(x_mny[final_valid], y_tgt[final_valid], "-", linewidth=1.8, label=f"{target} smile @ ~{int(T_days)}d")
-                ax.plot(x_mny[final_valid], y_syn[final_valid], "--", linewidth=1.8, label="Synthetic (corr-matrix)")
+                ax.plot(
+                    x_mny[final_valid],
+                    y_tgt[final_valid],
+                    "-",
+                    linewidth=1.8,
+                    label=f"{target} smile @ ~{int(T_days)}d",
+                )
+                mode_lbl = (weight_mode.split("_")[0] if weight_mode else "")
+                if mode_lbl == "corr":
+                    mode_lbl = "relative weight matrix"
+                syn_label = f"Synthetic ETF surface ({mode_lbl})" if mode_lbl else "Synthetic ETF surface"
+                ax.plot(
+                    x_mny[final_valid],
+                    y_syn[final_valid],
+                    "--",
+                    linewidth=1.8,
+                    label=syn_label,
+                )
             else:
                 ax.text(0.5, 0.5, "Insufficient valid data for comparison", ha="center", va="center")
             ax.set_xlabel("Moneyness (K/S)")
@@ -844,6 +869,10 @@ class PlotManager:
         asof = settings["asof"]
         model = settings["model"]
         ci = settings["ci"]
+        wm = settings.get("weight_mode")
+        mode_lbl = wm.split("_")[0] if wm else ""
+        if mode_lbl == "corr":
+            mode_lbl = "relative weight matrix"
 
         T_sel = float(Ts[i])
         # pick nearest slice to T_sel
@@ -998,13 +1027,14 @@ class PlotManager:
                         # Plot the synthetic smile with proper alignment
                         final_valid = np.isfinite(x_mny) & np.isfinite(y_syn)
                         if np.sum(final_valid) >= 2:
+                            syn_label = f"Synthetic ETF smile ({mode_lbl})" if mode_lbl else "Synthetic ETF smile"
                             ax.plot(
                                 x_mny[final_valid],
                                 y_syn[final_valid],
                                 linestyle="--",
                                 linewidth=1.5,
                                 alpha=0.9,
-                                label="Synthetic smile (corr-matrix)",
+                                label=syn_label,
                             )
                 except Exception as e:
                     print(f"Warning: Failed to plot synthetic smile overlay: {e}")
@@ -1014,13 +1044,14 @@ class PlotManager:
                         y_syn = syn_surface[col_syn].astype(float).to_numpy()
                         valid = np.isfinite(x_mny) & np.isfinite(y_syn)
                         if np.sum(valid) >= 2:
+                            syn_label = f"Synthetic ETF smile ({mode_lbl})" if mode_lbl else "Synthetic ETF smile"
                             ax.plot(
                                 x_mny[valid],
                                 y_syn[valid],
                                 linestyle="--",
                                 linewidth=1.5,
                                 alpha=0.9,
-                                label="Synthetic smile (corr-matrix)",
+                                label=syn_label,
                             )
                     except Exception:
                         pass


### PR DESCRIPTION
## Summary
- Rename `Corr Matrix` plot references to `Relative Weight Matrix`
- Show `relative weight matrix` as the correlation-based weight method in synthetic ETF overlays

## Testing
- `pytest` *(fails: ImportError: cannot import name 'save_calc_cache' from 'analysis.cache_io')*

------
https://chatgpt.com/codex/tasks/task_e_68a7671e8c6483338d6aacd352b421dc