### PR TITLE
Add 90-day IV weighting and regression for spillover analysis

### DIFF
--- a/tests/test_vol_spillover.py
+++ b/tests/test_vol_spillover.py
@@ -1,7 +1,10 @@
 import pandas as pd
 import numpy as np
 
-from analysis.spillover.vol_spillover import compute_responses
+from analysis.spillover.vol_spillover import (
+    compute_responses,
+    compute_weights_and_regression,
+)
 
 
 def test_compute_responses_horizon_offsets():
@@ -21,3 +24,44 @@ def test_compute_responses_horizon_offsets():
     responses = compute_responses(df, events, peers, horizons=[1, 2])
     result = responses.sort_values('h')['peer_pct'].tolist()
     assert np.allclose(result, [0.2, 0.3])
+
+
+def test_weighting_and_regression_90d(monkeypatch):
+    dates = pd.date_range('2023-01-01', periods=100)
+    base = 100.0
+    t_ret = np.sin(np.linspace(0, 10, 100)) * 0.01
+    p1_ret = 0.6 * t_ret + 0.001  # high correlation
+    p2_ret = 0.2 * t_ret + 0.001 * np.cos(np.linspace(0, 3, 100))
+
+    def build_iv(r):
+        return base * np.exp(np.cumsum(r))
+
+    df = pd.DataFrame({
+        'date': list(dates) * 3,
+        'ticker': ['AAA'] * 100 + ['BBB'] * 100 + ['CCC'] * 100,
+        'atm_iv': np.concatenate([
+            build_iv(t_ret),
+            build_iv(p1_ret),
+            build_iv(p2_ret),
+        ]),
+    })
+
+    def fake_get_groups(ticker, conn=None):
+        return ['grp'] if ticker == 'AAA' else []
+
+    def fake_load_group(name, conn=None):
+        return {'peer_tickers': ['BBB', 'CCC']} if name == 'grp' else None
+
+    monkeypatch.setattr(
+        'analysis.spillover.vol_spillover.get_groups_for_target', fake_get_groups
+    )
+    monkeypatch.setattr(
+        'analysis.spillover.vol_spillover.load_ticker_group', fake_load_group
+    )
+
+    weights, betas = compute_weights_and_regression(df, 'AAA', window=90)
+
+    assert np.isclose(weights.sum(), 1.0)
+    assert weights['BBB'] > weights['CCC']
+    assert np.isclose(betas['BBB'], 0.6, atol=0.05)
+    assert np.isclose(betas['CCC'], 0.2, atol=0.05)


### PR DESCRIPTION
## Summary
- compute correlation-based weights and regression betas from 90-day IV history using peers defined in `ticker_groups`
- pull peer relationships from stored ticker groups rather than manual selection
- test weighting/regression with patched ticker group lookup and cache invalidation helpers

## Testing
- `pytest tests/test_vol_spillover.py::test_weighting_and_regression_90d tests/test_cache_io.py::test_cache_reuse_when_raw_unchanged tests/test_cache_io.py::test_cache_invalidated_on_raw_update -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7906197608333b69381c6fc7b220c