### PR TITLE
Precompute term plot data outside GUI

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -1104,7 +1104,8 @@ class PlotManager:
             ax,
             atm_curve,
             x_units=x_units,
-            fit=True,
+            fit_x=data.get("fit_x"),
+            fit_y=data.get("fit_y"),
             show_ci=bool(ci and ci > 0 and {"ci_lo", "ci_hi"}.issubset(atm_curve.columns)),
         )
         title = f"{target}  {asof}  ATM Term Structure  (N={len(atm_curve)})"

--- a/display/plotting/term_plot.py
+++ b/display/plotting/term_plot.py
@@ -6,16 +6,16 @@ import matplotlib.pyplot as plt
 from typing import Optional, Dict
 
 from analysis.confidence_bands import Bands
-from volModel.termFit import fit_term_structure, term_structure_iv
 
 
 def plot_atm_term_structure(
     ax: plt.Axes,
     atm_df: pd.DataFrame,
     x_units: str = "years",   # "years" or "days"
-    fit: bool = True,
+    *,
+    fit_x: Optional[np.ndarray] = None,
+    fit_y: Optional[np.ndarray] = None,
     show_ci: bool = False,    # draw CI bars if present
-    degree: int = 2,
 ) -> None:
     if atm_df is None or atm_df.empty:
         ax.text(0.5, 0.5, "No ATM data", ha="center", va="center")
@@ -42,15 +42,9 @@ def plot_atm_term_structure(
     else:
         ax.scatter(x_plot, y, s=30, alpha=0.9, label="ATM (fit)")
 
-    if fit and len(x) > degree:
-        try:
-            params = fit_term_structure(x, y, degree=degree)
-            grid = np.linspace(x.min(), x.max(), 200)
-            fit_y = term_structure_iv(grid, params)
-            grid_plot = grid * 365.25 if x_units == "days" else grid
-            ax.plot(grid_plot, fit_y, linestyle="--", alpha=0.6, label="Term fit")
-        except Exception:
-            pass
+    if fit_x is not None and fit_y is not None:
+        grid_plot = fit_x * 365.25 if x_units == "days" else fit_x
+        ax.plot(grid_plot, fit_y, linestyle="--", alpha=0.6, label="Term fit")
 
     ax.set_xlabel(x_label)
     ax.set_ylabel("Implied Vol (ATM)")


### PR DESCRIPTION
## Summary
- Precompute ATM term structure fit in `prepare_term_data` and return fit arrays
- Update term plot utility to accept precomputed fit data instead of fitting
- Pass precomputed term fit from `PlotManager` to plotting function to avoid GUI-side computation

## Testing
- `pytest` *(fails: ImportError: cannot import name 'pca_weights' from 'analysis.beta_builder')*


------
https://chatgpt.com/codex/tasks/task_e_68a79784cb9c833396b3eb39170372f7