### PR TITLE
Fix synthetic ETF viewer import to avoid heavy dependency

### DIFF
--- a/display/plotting/display_viewers_synthetic_etf_viewer.py
+++ b/display/plotting/display_viewers_synthetic_etf_viewer.py
@@ -8,8 +8,8 @@ Features:
 - Optional save to disk
 
 Usage:
-    from analysis.synthetic_etf import SyntheticETFBuilder, SyntheticETFConfig
-    from display.viewers.synthetic_etf_viewer import show_synthetic_etf
+    from analysis.analysis_synthetic_etf import SyntheticETFBuilder, SyntheticETFConfig
+    from display.plotting.display_viewers_synthetic_etf_viewer import show_synthetic_etf
 
     cfg = SyntheticETFConfig(target="SPY", peers=("QQQ","IWM"))
     builder = SyntheticETFBuilder(cfg)
@@ -25,7 +25,10 @@ import pandas as pd
 from typing import Optional
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  # needed for 3D plotting
 
-from analysis.analysis_synthetic_etf import SyntheticETFArtifacts
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from analysis.analysis_synthetic_etf import SyntheticETFArtifacts
 
 
 def _as_float_index(idx) -> list[float]:
@@ -39,7 +42,7 @@ def _as_float_index(idx) -> list[float]:
 
 
 def _extract_latest(
-    artifacts: SyntheticETFArtifacts, target: str
+    artifacts: 'SyntheticETFArtifacts', target: str
 ) -> tuple[
     Optional[pd.DataFrame],
     Optional[pd.DataFrame],
@@ -101,7 +104,7 @@ def _plot_surface(ax, df: pd.DataFrame, title: str, cmap="viridis"):
 
 
 def show_synthetic_etf(
-    artifacts: SyntheticETFArtifacts,
+    artifacts: 'SyntheticETFArtifacts',
     target: Optional[str] = None,
     save_path: Optional[str] = None,
     show_diff: bool = True,


### PR DESCRIPTION
## Summary
- avoid importing heavy analysis modules when loading synthetic ETF viewer
- document correct import path for `show_synthetic_etf`

## Testing
- `python - <<'PY'
import importlib
try:
    import display.plotting.display_viewers_synthetic_etf_viewer as m
    print('Imported successfully', m)
except Exception as e:
    print('Import failed:', e)
PY`
- `python - <<'PY'
import pandas as pd
from types import SimpleNamespace
from display.plotting.display_viewers_synthetic_etf_viewer import show_synthetic_etf

datestr='2024-01-01'
index=['0.95','1.05']
columns=['30','60']

tgt_df=pd.DataFrame([[0.1,0.2],[0.15,0.25]], index=index, columns=columns)
syn_df=tgt_df+0.01
rv_df=pd.DataFrame({'asof_date':[datestr,datestr],'pillar_days':[30,60],'iv_target':[0.1,0.2],'iv_synth':[0.11,0.21],'spread':[-0.01,-0.01],'z':[0.0,1.0],'pct_rank':[0.5,0.6]})
artifacts=SimpleNamespace(surfaces={'SPY':{datestr:tgt_df}}, synthetic_surfaces={datestr:syn_df}, rv_metrics=rv_df, meta={'target':'SPY'})
show_synthetic_etf(artifacts, target='SPY', save_path='test_output.png', show_diff=True)
print('done')
PY`
- `pytest -q` *(fails: ImportError: cannot import name 'pca_weights' from 'analysis.beta_builder')*


------
https://chatgpt.com/codex/tasks/task_e_68a79803346c833390ea0909fc05a9a3