### PR TITLE
Add feature table for engineered data

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -9,7 +9,7 @@ from .ticker_groups import (
     save_ticker_group, load_ticker_group, list_ticker_groups,
     delete_ticker_group, create_default_groups
 )
-from .db_utils import get_conn, ensure_initialized, ensure_indexes
+from .db_utils import get_conn, ensure_initialized, ensure_indexes, insert_features
 from .historical_saver import save_for_tickers
 from .underlying_prices import update_underlying_prices
 from .interest_rates import (
@@ -17,13 +17,36 @@ from .interest_rates import (
     list_interest_rates, delete_interest_rate, set_default_interest_rate,
     get_interest_rate_names, create_default_interest_rates
 )
+from .feature_engineering import (
+    build_pooled_iv_return_dataset_time_safe,
+    build_iv_return_dataset_time_safe,
+    build_target_peer_dataset,
+    add_all_features,
+    build_iv_panel,
+    finalize_dataset,
+)
+from data_loader_coordinator import (
+    DataCoordinator,
+    load_cores_with_auto_fetch,
+    validate_cores,
+)
 
 __all__ = [
     'save_ticker_group', 'load_ticker_group', 'list_ticker_groups',
     'delete_ticker_group', 'create_default_groups',
     'get_conn', 'ensure_initialized', 'ensure_indexes', 'save_for_tickers',
+    'insert_features',
     'update_underlying_prices',
     'save_interest_rate', 'load_interest_rate', 'get_default_interest_rate',
     'list_interest_rates', 'delete_interest_rate', 'set_default_interest_rate',
-    'get_interest_rate_names', 'create_default_interest_rates'
+    'get_interest_rate_names', 'create_default_interest_rates',
+    'build_pooled_iv_return_dataset_time_safe',
+    'build_iv_return_dataset_time_safe',
+    'build_target_peer_dataset',
+    'add_all_features',
+    'build_iv_panel',
+    'finalize_dataset',
+    'DataCoordinator',
+    'load_cores_with_auto_fetch',
+    'validate_cores',
 ]

--- a/data/db_schema.py
+++ b/data/db_schema.py
@@ -83,6 +83,17 @@ CREATE TABLE IF NOT EXISTS ticker_interest_rates (
 CREATE INDEX IF NOT EXISTS idx_interest_rates_default ON interest_rates(is_default);
 CREATE INDEX IF NOT EXISTS idx_ticker_rates_ticker ON ticker_interest_rates(ticker);
 CREATE INDEX IF NOT EXISTS idx_ticker_rates_date ON ticker_interest_rates(rate_date);
+
+-- Table for storing engineered features
+CREATE TABLE IF NOT EXISTS feature_table (
+    ts_event    TEXT    NOT NULL,
+    symbol      TEXT    NOT NULL,
+    features    TEXT    NOT NULL,
+    PRIMARY KEY (ts_event, symbol)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_table_symbol ON feature_table(symbol);
+CREATE INDEX IF NOT EXISTS idx_feature_table_ts ON feature_table(ts_event);
 """
 
 MIGRATIONS = [

--- a/data/feature_engineering.py
+++ b/data/feature_engineering.py
@@ -1,0 +1,567 @@
+import os
+import sqlite3
+import json
+import logging
+import warnings
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
+from scipy.stats import norm
+from scipy.optimize import brentq
+
+logging.basicConfig(level=logging.INFO)
+
+@contextmanager
+def suppress_runtime_warnings():
+    """Context manager to suppress specific runtime warnings during SABR calculations."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*invalid value encountered in log.*")
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*divide by zero encountered.*")
+        yield
+
+# Config
+DEFAULT_DB_PATH = Path(os.getenv("IV_DB_PATH", "data/iv_data_1m.db"))
+ANNUAL_MINUTES = 252 * 390
+
+# What to hide when predicting each target (preserved from original)
+HIDE_COLUMNS = {
+    "iv_ret_fwd": ["iv_ret_fwd_abs"],
+    "iv_ret_fwd_abs": ["iv_ret_fwd"],
+    "iv_clip": ["iv_ret_fwd", "iv_ret_fwd_abs"]
+}
+
+# Core features (preserved from original)
+CORE_FEATURE_COLS = [
+    "opt_volume", "time_to_expiry", "days_to_expiry", "strike_price",
+    "option_type_enc", "delta", "gamma", "vega", "hour", "minute", "day_of_week"
+]
+
+
+def _hagan_implied_vol(F: float, K: float, T: float, alpha: float, beta: float, rho: float, nu: float) -> float:
+    """Approximate Black implied volatility under the SABR model."""
+    with suppress_runtime_warnings():
+        if F <= 0 or K <= 0 or T <= 0 or alpha <= 0:
+            return np.nan
+
+        # Check for invalid parameters
+        if abs(rho) >= 1 or nu < 0 or not (0 <= beta <= 1):
+            return np.nan
+
+        if np.isclose(F, K):
+            term1 = alpha / (F ** (1 - beta))
+            term2 = 1 + (
+                ((1 - beta) ** 2 / 24) * (alpha ** 2 / (F ** (2 - 2 * beta)))
+                + (rho * beta * nu * alpha / (4 * F ** (1 - beta)))
+                + ((2 - 3 * rho ** 2) / 24) * (nu ** 2)
+            ) * T
+            return term1 * term2
+
+        FK_beta = (F * K) ** ((1 - beta) / 2)
+        logFK = np.log(F / K)
+        z = (nu / alpha) * FK_beta * logFK
+
+        if np.isclose(z, 0, atol=1e-7):
+            term2 = 1.0
+        else:
+            sqrt_term = np.sqrt(1 - 2 * rho * z + z * z)
+            log_arg = (sqrt_term + z - rho) / (1 - rho)
+
+            if log_arg <= 0 or (1 - rho) == 0:
+                return np.nan
+
+            x_z = np.log(log_arg)
+
+            if np.isclose(x_z, 0, atol=1e-12):
+                term2 = 1.0
+            else:
+                term2 = z / x_z
+
+        term1 = alpha / (FK_beta * (1 + ((1 - beta) ** 2 / 24) * (logFK ** 2) + ((1 - beta) ** 4 / 1920) * (logFK ** 4)))
+        term3 = 1 + (
+            ((1 - beta) ** 2 / 24) * (alpha ** 2 / (FK_beta ** 2))
+            + (rho * beta * nu * alpha / (4 * FK_beta))
+            + ((2 - 3 * rho ** 2) / 24) * (nu ** 2)
+        ) * T
+
+        result = term1 * term2 * term3
+
+        if not np.isfinite(result) or result <= 0:
+            return np.nan
+
+        return result
+
+
+def _solve_sabr_alpha(sigma: float, F: float, K: float, T: float, beta: float, rho: float, nu: float) -> float:
+    """Calibrate alpha for a single observation using Hagan's formula."""
+    if np.any(np.isnan([sigma, F, K, T])) or sigma <= 0 or F <= 0 or K <= 0 or T <= 0:
+        return np.nan
+
+    if abs(rho) >= 1 or nu < 0 or not (0 <= beta <= 1):
+        return np.nan
+
+    def objective(a: float) -> float:
+        if a <= 0:
+            return float('inf')
+        vol = _hagan_implied_vol(F, K, T, a, beta, rho, nu)
+        if np.isnan(vol):
+            return float('inf')
+        return vol - sigma
+
+    try:
+        obj_low = objective(1e-6)
+        obj_high = objective(5.0)
+
+        if not (np.isfinite(obj_low) and np.isfinite(obj_high)):
+            return np.nan
+
+        if obj_low * obj_high > 0:
+            return np.nan
+
+        return brentq(objective, 1e-6, 5.0, maxiter=100)
+    except (ValueError, RuntimeError):
+        return np.nan
+
+
+def _add_sabr_features(df: pd.DataFrame, beta: float = 0.5) -> pd.DataFrame:
+    """Compute simple SABR parameter features and drop raw price/IV columns."""
+    F_series = df.get("stock_close")
+    K_series = df.get("strike_price")
+    T_series = df.get("time_to_expiry")
+    sigma_series = df.get("iv_clip")
+    if F_series is None or K_series is None or T_series is None or sigma_series is None:
+        return df
+
+    F = F_series.astype(float).to_numpy()
+    K = K_series.astype(float).to_numpy()
+    T = np.maximum(T_series.astype(float).to_numpy(), 1e-9)
+    sigma = sigma_series.astype(float).to_numpy()
+
+    moneyness = (K / F) - 1.0
+    rho = np.tanh(moneyness * 5.0)
+    nu_series = (
+        df["iv_clip"].astype(float).rolling(30).std() * np.sqrt(ANNUAL_MINUTES / 30)
+    ).shift(1)
+    nu = nu_series.to_numpy()
+
+    alpha = np.array([
+        _solve_sabr_alpha(sig, f, k, t, beta, r, n)
+        for sig, f, k, t, r, n in zip(sigma, F, K, T, rho, nu)
+    ])
+
+    df["sabr_alpha"] = alpha
+    df["sabr_beta"] = beta
+    df["sabr_rho"] = rho
+    df["sabr_nu"] = nu
+
+    df = df.drop(columns=[c for c in ["stock_close", "iv_clip"] if c in df.columns])
+    return df
+
+
+def add_all_features(df: pd.DataFrame, forward_steps: int = 1, r: float = 0.045) -> pd.DataFrame:
+    """Centralized feature engineering (preserves all original feature logic)."""
+    df = df.copy()
+
+    log_col = np.log(df["iv_clip"].astype(float))
+    fwd = log_col.shift(-forward_steps) - log_col
+    df["iv_ret_fwd"] = fwd
+    df["iv_ret_fwd_abs"] = fwd.abs()
+
+    S = df["stock_close"].astype(float).to_numpy()
+    K = df["strike_price"].astype(float).to_numpy()
+    T = np.maximum(df["time_to_expiry"].astype(float).to_numpy(), 1e-9)
+    sig = df["iv_clip"].astype(float).to_numpy()
+    sqrtT = np.sqrt(T)
+    d1 = (np.log(S / K) + (r + 0.5 * sig * sig) * T) / (sig * sqrtT)
+    pdf = np.exp(-0.5 * d1 * d1) / np.sqrt(2.0 * np.pi)
+    is_call = df["option_type"].astype(str).str.upper().str[0].eq("C").to_numpy()
+    df["delta"] = np.where(is_call, norm.cdf(d1), norm.cdf(d1) - 1.0)
+    df["gamma"] = pdf / (S * sig * sqrtT)
+    df["vega"] = S * pdf * sqrtT
+
+    df["days_to_expiry"] = (df["time_to_expiry"] * 365.0).astype("float32")
+    df["option_type_enc"] = (df["option_type"].astype(str).str.upper().str[0]
+                            .map({"P": 0, "C": 1}).astype("float32"))
+
+    if "stock_close" in df.columns:
+        logS = np.log(df["stock_close"].astype(float))
+        ret_1m = logS.diff()
+        rv = ret_1m.rolling(30).std()
+        df["rv_30m"] = (rv * np.sqrt(ANNUAL_MINUTES / 30)).shift(1)
+
+    if "opt_volume" in df.columns:
+        pct_change = df["opt_volume"].pct_change()
+        df["opt_vol_change_1m"] = (pct_change.replace([np.inf, -np.inf], np.nan).fillna(0.0))
+        df["opt_vol_roll_15m"] = df["opt_volume"].rolling(15).mean().shift(1)
+
+    df = _add_sabr_features(df)
+
+    return df
+
+
+def build_iv_panel(cores: Dict[str, pd.DataFrame], tolerance: str = "2s") -> pd.DataFrame:
+    """Centralized IV panel building (preserves original merge logic)."""
+    tol = pd.Timedelta(tolerance)
+    iv_wide = None
+
+    for ticker, df in cores.items():
+        if df is None or df.empty or not {"ts_event", "iv_clip"}.issubset(df.columns):
+            continue
+
+        tmp = df[["ts_event", "iv_clip"]].rename(columns={"iv_clip": f"IV_{ticker}"}).copy()
+        tmp["ts_event"] = pd.to_datetime(tmp["ts_event"], utc=True, errors="coerce")
+        tmp = tmp.dropna(subset=["ts_event", f"IV_{ticker}"]).sort_values("ts_event")
+        tmp[f"IVRET_{ticker}"] = np.log(tmp[f"IV_{ticker}"]) - np.log(tmp[f"IV_{ticker}"].shift(1))
+        tmp = tmp[["ts_event", f"IV_{ticker}", f"IVRET_{ticker}"]]
+
+        if iv_wide is None:
+            iv_wide = tmp
+        else:
+            iv_wide = pd.merge_asof(
+                iv_wide.sort_values("ts_event"), tmp, on="ts_event",
+                direction="backward", tolerance=tol
+            )
+
+    return iv_wide if iv_wide is not None else pd.DataFrame(columns=["ts_event"])
+
+
+def finalize_dataset(df: pd.DataFrame, target_col: str, drop_symbol: bool = True, debug: bool = False) -> pd.DataFrame:
+    """Centralized dataset finalization (preserves original cleanup logic)."""
+    out = df.copy()
+
+    if debug:
+        debug_dir = Path("debug_snapshots")
+        debug_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        raw_snapshot_path = debug_dir / f"raw_data_{target_col}_{timestamp}.csv"
+        out.to_csv(raw_snapshot_path, index=False)
+        print(f"DEBUG: Saved raw data snapshot to {raw_snapshot_path}")
+
+    for c in out.columns:
+        if c != "ts_event":
+            out[c] = pd.to_numeric(out[c], errors="coerce")
+
+    initial_rows = len(out)
+    out = out.dropna(subset=[target_col])
+    dropped_target = initial_rows - len(out)
+
+    if debug and dropped_target > 0:
+        print(f"DEBUG: Dropped {dropped_target} rows with missing {target_col}")
+
+    hidden_cols = []
+    for col in HIDE_COLUMNS.get(target_col, []):
+        if col in out.columns:
+            out = out.drop(columns=col)
+            hidden_cols.append(col)
+
+    if debug and hidden_cols:
+        print(f"DEBUG: Hidden leaky columns for {target_col}: {hidden_cols}")
+
+    leak_cols = [c for c in out.columns if c in {"stock_close", "iv_clip"} or c.startswith("IV_") or c.startswith("IVRET_")]
+    if leak_cols:
+        out = out.drop(columns=leak_cols)
+        if debug:
+            print(f"DEBUG: Removed leak columns: {leak_cols}")
+
+    if drop_symbol and "symbol" in out.columns:
+        out = out.drop(columns=["symbol"])
+        if debug:
+            print(f"DEBUG: Dropped symbol column")
+
+    out = out.reset_index(drop=True)
+    out = _normalize_numeric_features(out, target_col=target_col)
+
+    if debug:
+        print(f"DEBUG: Final dataset shape: {out.shape}")
+        print(f"DEBUG: Final columns: {list(out.columns)}")
+        final_snapshot_path = debug_dir / f"final_data_{target_col}_{timestamp}.csv"
+        out.to_csv(final_snapshot_path, index=False)
+        print(f"DEBUG: Saved final data snapshot to {final_snapshot_path}")
+        info_path = debug_dir / f"column_info_{target_col}_{timestamp}.json"
+        column_info = {
+            "target_column": target_col,
+            "final_columns": list(out.columns),
+            "hidden_columns": hidden_cols,
+            "leak_columns": leak_cols,
+            "initial_rows": initial_rows,
+            "final_rows": len(out),
+            "dropped_rows": dropped_target,
+        }
+        with open(info_path, 'w') as f:
+            json.dump(column_info, f, indent=2, default=str)
+        print(f"DEBUG: Saved column info to {info_path}")
+
+    logging.getLogger(__name__).info("Final dataset columns: %s", list(out.columns))
+
+    return out
+
+
+def build_pooled_iv_return_dataset_time_safe(
+    tickers: Sequence[str],
+    start: Optional[pd.Timestamp] = None,
+    end: Optional[pd.Timestamp] = None,
+    r: float = 0.045,
+    forward_steps: int = 1,
+    tolerance: str = "2s",
+    db_path: Path | str | None = None,
+    cores: Optional[Dict[str, pd.DataFrame]] = None,
+    debug: bool = False,
+) -> pd.DataFrame:
+    """Build pooled dataset for forecasting forward IV return, keeping peer IV/IVRET columns."""
+
+    if debug:
+        print(f"DEBUG: Building pooled dataset for {len(tickers)} tickers")
+        print(f"DEBUG: Parameters - forward_steps: {forward_steps}, tolerance: {tolerance}")
+
+    if cores is None:
+        from data_loader_coordinator import load_cores_with_auto_fetch
+        cores = load_cores_with_auto_fetch(tickers, start, end, db_path)
+
+    if debug:
+        print(f"DEBUG: Cores loaded for tickers: {list(cores.keys())}")
+        for ticker, core in cores.items():
+            print(f"DEBUG: {ticker} core shape: {core.shape if core is not None else 'None'}")
+
+    panel = build_iv_panel(cores, tolerance=tolerance)
+
+    if debug:
+        print(f"DEBUG: IV panel shape: {panel.shape}")
+        if not panel.empty:
+            debug_dir = Path("debug_snapshots")
+            debug_dir.mkdir(exist_ok=True)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            panel_path = debug_dir / f"iv_panel_{timestamp}.csv"
+            panel.to_csv(panel_path, index=False)
+            print(f"DEBUG: Saved IV panel to {panel_path}")
+
+    frames = []
+    for ticker in tickers:
+        if ticker not in cores:
+            if debug:
+                print(f"DEBUG: Skipping {ticker} - not in cores")
+            continue
+
+        if debug:
+            print(f"DEBUG: Processing {ticker}")
+
+        feats = add_all_features(cores[ticker], forward_steps=forward_steps, r=r)
+
+        if debug:
+            print(f"DEBUG: {ticker} after add_all_features: {feats.shape}")
+
+        feats = pd.merge_asof(
+            feats.sort_values("ts_event"), panel.sort_values("ts_event"),
+            on="ts_event", direction="backward", tolerance=pd.Timedelta(tolerance)
+        )
+
+        if debug:
+            print(f"DEBUG: {ticker} after panel merge: {feats.shape}")
+
+        out = feats.copy()
+        for c in out.columns:
+            if c != "ts_event":
+                out[c] = pd.to_numeric(out[c], errors="coerce")
+        out = out.dropna(subset=["iv_ret_fwd"])
+        for col in HIDE_COLUMNS.get("iv_ret_fwd", []):
+            if col in out.columns:
+                out = out.drop(columns=col)
+        for c in ["stock_close", "iv_clip"]:
+            if c in out.columns:
+                out = out.drop(columns=c)
+        out = out.reset_index(drop=True)
+        out = _normalize_numeric_features(out, target_col="iv_ret_fwd")
+        if debug:
+            print(f"DEBUG: {ticker} after finalization: {out.shape}")
+        frames.append(out)
+
+    if not frames:
+        if debug:
+            print("DEBUG: No frames to concatenate - returning empty DataFrame")
+        return pd.DataFrame()
+
+    pooled = pd.concat(frames, ignore_index=True)
+    if pooled.empty:
+        if debug:
+            print("DEBUG: Pooled dataset is empty after concatenation")
+        return pooled
+
+    if debug:
+        print(f"DEBUG: Pooled dataset after concatenation: {pooled.shape}")
+
+    pooled = pd.get_dummies(pooled, columns=["symbol"], prefix="sym", dtype=float)
+
+    for ticker in tickers:
+        col = f"sym_{ticker}"
+        if col not in pooled.columns:
+            pooled[col] = 0.0
+
+    front = ["iv_ret_fwd"]
+    if "iv_ret_fwd_abs" in pooled.columns:
+        front.append("iv_ret_fwd_abs")
+    if "iv_clip" in pooled.columns:
+        front.append("iv_clip")
+    onehots = [f"sym_{t}" for t in tickers]
+    other = [c for c in pooled.columns if c not in front + onehots]
+
+    final_pooled = pooled[front + other + onehots]
+
+    if debug:
+        print(f"DEBUG: Final pooled dataset shape: {final_pooled.shape}")
+        debug_dir = Path("debug_snapshots")
+        debug_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        pooled_path = debug_dir / f"pooled_final_{timestamp}.csv"
+        final_pooled.to_csv(pooled_path, index=False)
+        print(f"DEBUG: Saved final pooled dataset to {pooled_path}")
+
+    return final_pooled
+
+
+def build_iv_return_dataset_time_safe(
+    tickers: Sequence[str],
+    start: Optional[pd.Timestamp] = None,
+    end: Optional[pd.Timestamp] = None,
+    r: float = 0.045,
+    forward_steps: int = 15,
+    tolerance: str = "2s",
+    db_path: Path | str | None = None,
+    cores: Optional[Dict[str, pd.DataFrame]] = None,
+    debug: bool = False,
+) -> Dict[str, pd.DataFrame]:
+    """Build per‑ticker datasets for forecasting forward IV return."""
+
+    if debug:
+        print(f"DEBUG: Building per-ticker datasets for {len(tickers)} tickers")
+
+    if cores is None:
+        from data_loader_coordinator import load_cores_with_auto_fetch
+        cores = load_cores_with_auto_fetch(tickers, start, end, db_path)
+
+    panel = build_iv_panel(cores, tolerance=tolerance)
+
+    datasets = {}
+    for ticker in tickers:
+        if ticker not in cores:
+            if debug:
+                print(f"DEBUG: Skipping {ticker} - not in cores")
+            continue
+
+        if debug:
+            print(f"DEBUG: Processing per-ticker dataset for {ticker}")
+
+        feats = add_all_features(cores[ticker], forward_steps=forward_steps, r=r)
+
+        feats = pd.merge_asof(
+            feats.sort_values("ts_event"), panel.sort_values("ts_event"),
+            on="ts_event", direction="backward", tolerance=pd.Timedelta(tolerance)
+        )
+
+        datasets[ticker] = finalize_dataset(feats, "iv_ret_fwd", drop_symbol=False, debug=debug)
+
+    if debug:
+        print(f"DEBUG: Built {len(datasets)} per-ticker datasets")
+
+    return datasets
+
+
+def build_target_peer_dataset(
+    target: str,
+    tickers: Sequence[str],
+    start: Optional[pd.Timestamp] = None,
+    end: Optional[pd.Timestamp] = None,
+    r: float = 0.045,
+    forward_steps: int = 1,
+    tolerance: str = "2s",
+    db_path: Path | str | None = None,
+    target_kind: str = "iv_ret",
+    cores: Optional[Dict[str, pd.DataFrame]] = None,
+    debug: bool = False,
+) -> pd.DataFrame:
+    """Build dataset for single target vs peers."""
+
+    if debug:
+        print(f"DEBUG: Building target-peer dataset for {target} vs {len(tickers)} tickers")
+        print(f"DEBUG: target_kind: {target_kind}")
+
+    if target not in tickers:
+        raise AssertionError("target must be included in tickers")
+
+    if cores is None:
+        from data_loader_coordinator import load_cores_with_auto_fetch
+        cores = load_cores_with_auto_fetch(tickers, start, end, db_path)
+
+    if target not in cores:
+        raise ValueError(f"Target {target} produced no valid core")
+
+    panel = build_iv_panel(cores, tolerance=tolerance)
+    feats = add_all_features(cores[target], forward_steps=forward_steps, r=r)
+
+    feats = pd.merge_asof(
+        feats.sort_values("ts_event"), panel.sort_values("ts_event"),
+        on="ts_event", direction="backward", tolerance=pd.Timedelta(tolerance)
+    )
+
+    if target_kind in ("iv_ret", "iv_ret_fwd"):
+        target_col = "iv_ret_fwd"
+    elif target_kind == "iv_ret_fwd_abs":
+        target_col = "iv_ret_fwd_abs"
+    elif target_kind == "iv":
+        target_col = "iv_clip"
+    else:
+        raise ValueError(
+            "target_kind must be one of 'iv_ret', 'iv_ret_fwd', 'iv_ret_fwd_abs', or 'iv'"
+        )
+
+    if debug:
+        print(f"DEBUG: Using target column: {target_col}")
+        print(f"DEBUG: Dataset shape before finalization: {feats.shape}")
+
+    feats = finalize_dataset(feats, target_col, drop_symbol=True, debug=debug)
+    final_dataset = feats.rename(columns={target_col: "y"})
+
+    if debug:
+        print(f"DEBUG: Final target-peer dataset shape: {final_dataset.shape}")
+        debug_dir = Path("debug_snapshots")
+        debug_dir.mkdir(exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        target_peer_path = debug_dir / f"target_peer_{target}_{target_kind}_{timestamp}.csv"
+        final_dataset.to_csv(target_peer_path, index=False)
+        print(f"DEBUG: Saved target-peer dataset to {target_peer_path}")
+
+    return final_dataset
+
+
+def _normalize_numeric_features(out: pd.DataFrame, target_col: str) -> pd.DataFrame:
+    keep = {"ts_event"}
+    skip_prefixes = ("sym_",)
+    skip_exact = {target_col}
+
+    cols = []
+    for c in out.columns:
+        if c in keep or c in skip_exact:
+            continue
+        if any(c.startswith(p) for p in skip_prefixes):
+            continue
+        if is_numeric_dtype(out[c]):
+            cols.append(c)
+
+    if cols:
+        mu = out[cols].mean()
+        sd = out[cols].std().replace(0.0, 1.0).fillna(1.0)
+        out[cols] = (out[cols] - mu) / sd
+        out.attrs["norm_means"] = {k: float(mu[k]) for k in mu.index}
+        out.attrs["norm_stds"] = {k: float(sd[k]) for k in sd.index}
+    return out
+
+__all__ = [
+    "build_pooled_iv_return_dataset_time_safe",
+    "build_iv_return_dataset_time_safe",
+    "build_target_peer_dataset",
+    "add_all_features",
+    "build_iv_panel",
+    "finalize_dataset",
+]

--- a/data/historical_saver.py
+++ b/data/historical_saver.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 from typing import Iterable
 
-from .db_utils import get_conn, ensure_initialized, insert_quotes
+from .db_utils import get_conn, ensure_initialized, insert_quotes, insert_features
 from .data_downloader import download_raw_option_data
 from .data_pipeline import enrich_quotes
 from .interest_rates import STANDARD_RISK_FREE_RATE, STANDARD_DIVIDEND_YIELD
+from .feature_engineering import add_all_features
+import pandas as pd
 
 def save_for_tickers(
     tickers: Iterable[str],
@@ -31,6 +33,24 @@ def save_for_tickers(
 
         total += insert_quotes(conn, enriched.to_dict(orient="records"))
         print(f"Inserted {t}: {len(enriched)} rows")
+
+        # Compute feature rows and persist to feature_table
+        feat_input = enriched.rename(
+            columns={
+                "asof_date": "ts_event",
+                "ticker": "symbol",
+                "K": "strike_price",
+                "call_put": "option_type",
+                "sigma": "iv_clip",
+                "S": "stock_close",
+                "volume_raw": "opt_volume",
+                "T": "time_to_expiry",
+            }
+        )
+        feat_input["ts_event"] = pd.to_datetime(feat_input["ts_event"], errors="coerce")
+        features = add_all_features(feat_input)
+        features["ts_event"] = features["ts_event"].astype(str)
+        insert_features(conn, features.to_dict(orient="records"))
     return total
 
 if __name__ == "__main__":

--- a/data_loader_coordinator.py
+++ b/data_loader_coordinator.py
@@ -1,0 +1,441 @@
+"""Data loader coordinator - helps orchestrate data loading across existing modules.
+
+This module doesn't duplicate functionality but provides a clean interface
+ to coordinate between feature_engineering.py, fetch_data_sqlite.py, and 
+train_peer_effects.py.
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Dict, Sequence, Optional
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+from scipy.optimize import brentq
+
+# Import existing functions with safe error handling
+try:
+    from fetch_data_sqlite import fetch_and_save, get_conn, init_schema
+except ImportError as e:
+    print(f"Warning: Could not import fetch_data_sqlite functions: {e}")
+    fetch_and_save = None
+    get_conn = None
+    init_schema = None
+
+
+def _get_table_columns(conn: sqlite3.Connection, table_name: str) -> list:
+    """Get column names for a table."""
+    try:
+        cursor = conn.execute(f"PRAGMA table_info({table_name})")
+        return [row[1] for row in cursor.fetchall()]
+    except Exception:
+        return []
+
+
+def _calculate_iv(price: float, S: float, K: float, T: float, cp: str, r: float) -> float:
+    """IV calculation (moved here to avoid circular imports)."""
+    if not np.isfinite([price, S, K, T, r]).all() or price <= 0 or S <= 0 or K <= 0 or T <= 0:
+        return np.nan
+    
+    intrinsic = max(S - K, 0.0) if cp.upper().startswith('C') else max(K - S, 0.0)
+    if price <= intrinsic + 1e-10:
+        return 1e-6
+        
+    def bs_price(sigma):
+        if T <= 0 or sigma <= 0 or S <= 0 or K <= 0:
+            return intrinsic
+        sqrtT = np.sqrt(T)
+        d1 = (np.log(S / K) + (r + 0.5 * sigma * sigma) * T) / (sigma * sqrtT)
+        d2 = d1 - sigma * sqrtT
+        if cp.upper().startswith('C'):
+            return S * norm.cdf(d1) - K * np.exp(-r * T) * norm.cdf(d2)
+        else:
+            return K * np.exp(-r * T) * norm.cdf(-d2) - S * norm.cdf(-d1)
+    
+    try:
+        return brentq(lambda sig: bs_price(sig) - price, 1e-6, 5.0, maxiter=100, xtol=1e-8)
+    except:
+        return np.nan
+
+
+def _safe_table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    """Safely check if a table exists in the database."""
+    try:
+        result = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name= ?",
+            (table_name,)
+        ).fetchone()
+        return result is not None
+    except Exception:
+        return False
+
+
+def _safe_data_exists(conn: sqlite3.Connection, table: str, ticker: str, start: str = None, end: str = None) -> bool:
+    """Safely check if data exists for a ticker in the given time range."""
+    try:
+        where_clauses, params = ["ticker= ?"], [ticker]
+        if start:
+            where_clauses.append("ts_event >= ?")
+            params.append(pd.to_datetime(start).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+        if end:
+            where_clauses.append("ts_event <= ?")
+            params.append(pd.to_datetime(end).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+        
+        query = f"SELECT COUNT(*) FROM {table} WHERE {' AND '.join(where_clauses)}"
+        result = conn.execute(query, params).fetchone()
+        return result[0] > 0 if result else False
+    except Exception:
+        return False
+
+
+def _populate_atm_slices(conn: sqlite3.Connection, ticker: str) -> None:
+    """Populate ATM slices table from processed_merged_1m data."""
+    try:
+        # Get column schemas for both tables
+        atm_cols = _get_table_columns(conn, "atm_slices_1m")
+        processed_cols = _get_table_columns(conn, "processed_merged_1m")
+        
+        if not atm_cols or not processed_cols:
+            print(f"  ✗ Could not get table schemas for {ticker}")
+            return
+        
+        # Find common columns (excluding any extras)
+        common_cols = [col for col in atm_cols if col in processed_cols]
+        
+        if len(common_cols) < 10:  # Sanity check
+            print(f"  ✗ Too few common columns ({len(common_cols)}) for {ticker}")
+            return
+        
+        # Build the query with exact column matching
+        cols_str = ", ".join(common_cols)
+        
+        q = f"""
+        INSERT OR REPLACE INTO atm_slices_1m ({cols_str})
+        SELECT {cols_str}
+        FROM (
+            SELECT
+                {cols_str},
+                ROW_NUMBER() OVER (
+                  PARTITION BY ticker, ts_event, expiry_date
+                  ORDER BY ABS(strike_price - stock_close)
+                ) rn
+            FROM processed_merged_1m
+            WHERE ticker = ?
+        )
+        WHERE rn = 1;
+        """
+        
+        result = conn.execute(q, (ticker,))
+        conn.commit()
+        rows_affected = result.rowcount
+        print(f"  ✓ Populated ATM slices for {ticker} ({rows_affected} rows)")
+        
+    except Exception as e:
+        print(f"  ✗ Failed to populate ATM slices for {ticker}: {e}")
+
+
+def load_ticker_core(ticker: str, start=None, end=None, r=0.045, db_path=None) -> pd.DataFrame:
+    """Load ticker core data with IV calculation."""
+    
+    if db_path is None:
+        db_path = Path(os.getenv("IV_DB_PATH", "data/iv_data_1m.db"))
+    
+    # Check if database file exists
+    if not Path(db_path).exists():
+        print(f"Database file does not exist: {db_path}")
+        return pd.DataFrame()
+    
+    try:
+        with sqlite3.connect(str(db_path)) as conn:
+            # Try tables in order of preference
+            table = None
+            for candidate in ["atm_slices_1m", "processed_merged_1m", "processed_merged"]:
+                if _safe_table_exists(conn, candidate):
+                    if _safe_data_exists(conn, candidate, ticker, start, end):
+                        table = candidate
+                        break
+            
+            if table is None:
+                print(f"No data found for {ticker} in any table")
+                return pd.DataFrame()
+            
+            # If we have processed_merged_1m but not atm_slices_1m, populate ATM slices
+            if table == "processed_merged_1m" and _safe_table_exists(conn, "atm_slices_1m"):
+                if not _safe_data_exists(conn, "atm_slices_1m", ticker, start, end):
+                    _populate_atm_slices(conn, ticker)
+                    if _safe_data_exists(conn, "atm_slices_1m", ticker, start, end):
+                        table = "atm_slices_1m"
+            
+            where_clauses, params = ["ticker= ?"], [ticker]
+            if start:
+                start_ts = pd.to_datetime(start).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                where_clauses.append("ts_event >= ?")
+                params.append(start_ts)
+                print(f"DEBUG: Filtering {ticker} with start >= {start} (converted to {start_ts})")
+            if end:
+                end_ts = pd.to_datetime(end).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                where_clauses.append("ts_event <= ?")
+                params.append(end_ts)
+                print(f"DEBUG: Filtering {ticker} with end <= {end} (converted to {end_ts})")
+            
+            required_cols = ["ts_event", "expiry_date", "opt_symbol", "stock_symbol",
+                             "opt_close", "stock_close", "opt_volume", "stock_volume",
+                             "option_type", "strike_price", "time_to_expiry", "moneyness"]
+            available_cols = _get_table_columns(conn, table)
+            select_cols = [col for col in required_cols if col in available_cols]
+            
+            if len(select_cols) < 8:
+                print(f"Insufficient columns in {table} for {ticker}")
+                return pd.DataFrame()
+            
+            cols_str = ", ".join(select_cols)
+            
+            if table == "atm_slices_1m":
+                query = f"""
+                SELECT {cols_str}
+                FROM {table} WHERE {' AND '.join(where_clauses)}
+                ORDER BY ts_event
+                """
+            else:
+                query = f"""
+                SELECT {cols_str}
+                FROM (
+                    SELECT {cols_str},
+                           ROW_NUMBER() OVER (
+                               PARTITION BY ticker, ts_event, expiry_date
+                               ORDER BY ABS(strike_price - stock_close)
+                           ) as rn
+                    FROM {table}
+                    WHERE {' AND '.join(where_clauses)}
+                ) ranked
+                WHERE rn = 1
+                ORDER BY ts_event
+                """
+            
+            df = pd.read_sql_query(query, conn, params=params, parse_dates=["ts_event", "expiry_date"])
+    except Exception as e:
+        print(f"Error loading data for {ticker}: {e}")
+        return pd.DataFrame()
+    
+    if df.empty:
+        return df
+    
+    try:
+        df["iv"] = df.apply(lambda row: _calculate_iv(
+            row["opt_close"], row["stock_close"], row["strike_price"],
+            max(row["time_to_expiry"], 1e-6), row["option_type"], r
+        ), axis=1)
+        available_keep = [col for col in ["ts_event", "expiry_date", "iv", "opt_volume", "stock_close",
+                                          "stock_volume", "time_to_expiry", "strike_price", "option_type"]
+                          if col in df.columns]
+        df = df[available_keep].copy()
+        df["symbol"] = ticker
+        df["ts_event"] = pd.to_datetime(df["ts_event"], utc=True, errors="coerce")
+        df = df.dropna(subset=["iv"]).sort_values("ts_event").reset_index(drop=True)
+        df["iv_clip"] = df["iv"].clip(lower=1e-6)
+    except Exception as e:
+        print(f"Error processing IV data for {ticker}: {e}")
+        return pd.DataFrame()
+    
+    return df
+
+
+class DataCoordinator:
+    """Coordinates data loading and ensures consistency across modules."""
+    
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or Path(os.getenv("IV_DB_PATH", "data/iv_data_1m.db"))
+        self.api_key = os.getenv("DATABENTO_API_KEY")
+        
+    def _safe_fetch_data(self, ticker: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> bool:
+        """Safely attempt to fetch data using fetch_data_sqlite functions."""
+        if not self.api_key:
+            print(f"    ✗ No API key available for fetching {ticker}")
+            return False
+        if fetch_and_save is None:
+            print(f"    ✗ fetch_data_sqlite functions not available for {ticker}")
+            return False
+        try:
+            if not self.db_path.exists():
+                print(f"    Creating new database: {self.db_path}")
+                if get_conn and init_schema:
+                    conn = get_conn(self.db_path)
+                    init_schema(conn)
+                    conn.close()
+                else:
+                    print(f"    ✗ Cannot initialize database schema")
+                    return False
+            fetch_and_save(self.api_key, ticker, start_ts, end_ts, self.db_path, force=True)
+            return True
+        except Exception as e:
+            print(f"    ✗ Fetch failed for {ticker}: {e}")
+            return False
+    
+    def populate_missing_atm_slices(self, tickers: Sequence[str]) -> None:
+        """Populate ATM slices for tickers that have processed data but missing ATM slices."""
+        try:
+            with sqlite3.connect(str(self.db_path)) as conn:
+                for ticker in tickers:
+                    has_processed = _safe_data_exists(conn, "processed_merged_1m", ticker)
+                    has_atm = _safe_data_exists(conn, "atm_slices_1m", ticker)
+                    if has_processed and not has_atm:
+                        print(f"  Populating ATM slices for {ticker}...")
+                        _populate_atm_slices(conn, ticker)
+        except Exception as e:
+            print(f"Error populating ATM slices: {e}")
+    
+    def load_cores_with_fetch(
+        self,
+        tickers: Sequence[str],
+        start: str,
+        end: str,
+        auto_fetch: bool = True,
+        drop_zero_iv_ret: bool = False,
+    ) -> Dict[str, pd.DataFrame]:
+        """
+        Load ticker cores, automatically fetching missing data if possible.
+
+        Parameters
+        ----------
+        drop_zero_iv_ret: bool, optional
+            If True, rows where the instantaneous IV return is exactly zero
+            are removed from each core. The return is computed as the first
+            difference of log(iv_clip).
+        """
+        cores = {}
+        missing_tickers = []
+        
+        print(f"Loading cores for {len(tickers)} tickers...")
+        self.populate_missing_atm_slices(tickers)
+        for ticker in tickers:
+            try:
+                core = load_ticker_core(ticker, start=start, end=end, db_path=self.db_path)
+                if not core.empty:
+                    if drop_zero_iv_ret and "iv_clip" in core.columns:
+                        iv_ret = np.log(core["iv_clip"].astype(float)).diff()
+                        mask = (iv_ret != 0) & (~iv_ret.isna())
+                        dropped = int(len(core) - mask.sum())
+                        core = core[mask].copy()
+                        if dropped:
+                            print(f"    • {ticker}: dropped {dropped} rows with iv_ret=0")
+                    cores[ticker] = core
+                    print(f"  ✓ {ticker}: {len(core):,} rows")
+                else:
+                    missing_tickers.append(ticker)
+                    print(f"  ✗ {ticker}: no data found")
+            except Exception as e:
+                print(f"  ✗ {ticker}: error loading ({e})")
+                missing_tickers.append(ticker)
+        
+        if missing_tickers and auto_fetch:
+            print(f"Auto-fetching {len(missing_tickers)} missing tickers...")
+            start_ts = pd.Timestamp(start, tz="UTC")
+            end_ts = pd.Timestamp(end, tz="UTC")
+            for ticker in missing_tickers:
+                print(f"  Fetching {ticker}...")
+                if self._safe_fetch_data(ticker, start_ts, end_ts):
+                    try:
+                        core = load_ticker_core(ticker, start=start, end=end, db_path=self.db_path)
+                        if not core.empty:
+                            if drop_zero_iv_ret and "iv_clip" in core.columns:
+                                iv_ret = np.log(core["iv_clip"].astype(float)).diff()
+                                mask = (iv_ret != 0) & (~iv_ret.isna())
+                                dropped = int(len(core) - mask.sum())
+                                core = core[mask].copy()
+                                if dropped:
+                                    print(f"      • {ticker}: dropped {dropped} rows with iv_ret=0")
+                            cores[ticker] = core
+                            print(f"    ✓ Fetched {ticker}: {len(core):,} rows")
+                        else:
+                            print(f"    ✗ {ticker}: no data even after fetch")
+                    except Exception as e:
+                        print(f"    ✗ {ticker}: error loading after fetch ({e})")
+                else:
+                    print(f"    ✗ {ticker}: could not fetch data")
+        elif missing_tickers and not auto_fetch:
+            print(f"Skipping auto-fetch for {len(missing_tickers)} missing tickers (auto_fetch=False)")
+        
+        print(f"Final result: {len(cores)}/{len(tickers)} tickers loaded")
+        return cores
+
+    def validate_cores_for_analysis(
+        self,
+        cores: Dict[str, pd.DataFrame],
+        analysis_type: str = "general",
+        drop_zero_iv_ret: bool = False,
+    ) -> Dict[str, pd.DataFrame]:
+        """Validate cores are suitable for specific analysis types."""
+        valid_cores = {}
+        
+        for ticker, core in cores.items():
+            if core is None or core.empty:
+                print(f"Skipping {ticker}: empty core")
+                continue
+            if not {"ts_event", "iv_clip"}.issubset(core.columns):
+                print(f"Skipping {ticker}: missing required columns")
+                continue
+            if drop_zero_iv_ret and "iv_clip" in core.columns:
+                iv_ret = np.log(core["iv_clip"].astype(float)).diff()
+                mask = (iv_ret != 0) & (~iv_ret.isna())
+                dropped = int(len(core) - mask.sum())
+                core = core[mask].copy()
+                if dropped:
+                    print(f"  • {ticker}: dropped {dropped} rows with iv_ret=0")
+            if analysis_type == "peer_effects":
+                if len(core) < 100:
+                    print(f"Skipping {ticker}: insufficient data for peer effects ({len(core)} rows)")
+                    continue
+            elif analysis_type == "pooled":
+                if len(core) < 50:
+                    print(f"Skipping {ticker}: insufficient data for pooling ({len(core)} rows)")
+                    continue
+            valid_cores[ticker] = core
+        
+        return valid_cores
+    
+    def get_analysis_summary(self, cores: Dict[str, pd.DataFrame]) -> Dict:
+        """Get summary statistics for loaded cores."""
+        if not cores:
+            return {"status": "no_data"}
+        summary = {
+            "n_tickers": len(cores),
+            "tickers": list(cores.keys()),
+            "total_rows": sum(len(df) for df in cores.values()),
+            "date_ranges": {},
+            "avg_rows_per_ticker": sum(len(df) for df in cores.values()) // len(cores),
+        }
+        for ticker, core in cores.items():
+            if not core.empty and "ts_event" in core.columns:
+                dates = pd.to_datetime(core["ts_event"])
+                summary["date_ranges"][ticker] = {
+                    "start": dates.min().strftime("%Y-%m-%d"),
+                    "end": dates.max().strftime("%Y-%m-%d"),
+                    "rows": len(core),
+                }
+        return summary
+
+
+def load_cores_with_auto_fetch(
+    tickers: Sequence[str],
+    start: str,
+    end: str,
+    db_path: Optional[Path] = None,
+    auto_fetch: bool = True,
+    drop_zero_iv_ret: bool = False,
+) -> Dict[str, pd.DataFrame]:
+    """Convenience function that wraps DataCoordinator for simple usage."""
+    coordinator = DataCoordinator(db_path)
+    return coordinator.load_cores_with_fetch(tickers, start, end, auto_fetch, drop_zero_iv_ret)
+
+
+def validate_cores(
+    cores: Dict[str, pd.DataFrame],
+    analysis_type: str = "general",
+    drop_zero_iv_ret: bool = False,
+) -> Dict[str, pd.DataFrame]:
+    """Convenience function for core validation."""
+    coordinator = DataCoordinator()
+    return coordinator.validate_cores_for_analysis(cores, analysis_type, drop_zero_iv_ret)
+

--- a/tests/test_feature_table.py
+++ b/tests/test_feature_table.py
@@ -1,0 +1,21 @@
+import json
+from data.db_utils import get_conn, ensure_initialized, insert_features
+
+def test_insert_features_and_retrieve(tmp_path):
+    db_file = tmp_path / "tmp.db"
+    conn = get_conn(str(db_file))
+    ensure_initialized(conn)
+    rows = [{
+        "ts_event": "2024-01-01T00:00:00",
+        "symbol": "SPY",
+        "foo": 1.0,
+        "bar": 2.0,
+    }]
+    inserted = insert_features(conn, rows)
+    assert inserted == 1
+    cur = conn.execute("SELECT ts_event, symbol, features FROM feature_table")
+    ts_event, symbol, feat_json = cur.fetchone()
+    assert ts_event == "2024-01-01T00:00:00"
+    assert symbol == "SPY"
+    data = json.loads(feat_json)
+    assert data == {"foo": 1.0, "bar": 2.0}


### PR DESCRIPTION
## Summary
- define `feature_table` schema and indexes for storing engineered features
- add `insert_features` helper and update historical saver to populate feature table
- add `DataCoordinator` module to orchestrate core loading and expose it via the `data` package
- test inserting and retrieving feature rows

## Testing
- `pytest tests/test_feature_table.py -q`
- `pytest tests/test_volmodel_imports.py::test_termfit_exposes_sabr_and_svi -q`
- `pytest tests/test_auto_update.py::test_auto_update -q`


------
https://chatgpt.com/codex/tasks/task_e_68a791714f5c8333907796b17aa5f06c