### PR TITLE
Add historical parameter panel utility for spillover analysis

### DIFF
--- a/tests/test_historical_params.py
+++ b/tests/test_historical_params.py
@@ -3,6 +3,7 @@ import pandas as pd
 from analysis.historical_params import (
     historical_param_timeseries,
     historical_param_summary,
+    historical_param_panel,
 )
 
 
@@ -22,3 +23,10 @@ def test_historical_param_summary_matches_timeseries():
     assert row['mean'] == ts.mean()
     assert row['min'] == ts.min()
     assert row['max'] == ts.max()
+
+
+def test_historical_param_panel_pivot():
+    panel = historical_param_panel('sabr', 'alpha', ['QQQ', 'UNH'])
+    assert not panel.empty
+    assert set(['QQQ', 'UNH']).issubset(panel.columns)
+    assert panel.index.is_monotonic_increasing

--- a/tests/test_model_params_gui.py
+++ b/tests/test_model_params_gui.py
@@ -1,0 +1,22 @@
+import os
+import tkinter as tk
+import pytest
+
+from display.gui.model_params_gui import ModelParamsFrame
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY", "") == "", reason="requires X11 display")
+def test_param_panel_multi_ticker():
+    root = tk.Tk()
+    root.withdraw()
+    frame = ModelParamsFrame(root)
+    frame.ent_ticker.insert(0, "QQQ,UNH")
+    frame.cmb_model.set("sabr")
+    frame.ent_param.insert(0, "alpha")
+    frame._plot()
+    rows = [frame.table.tree.item(i)["values"] for i in frame.table.tree.get_children()]
+    assert len(rows) == 2
+    params = [r[1] for r in rows]
+    assert any("QQQ" in p for p in params)
+    assert any("UNH" in p for p in params)
+    root.destroy()


### PR DESCRIPTION
## Summary
- extend historical parameter utilities with `historical_param_panel` to fetch aligned parameter histories across tickers
- test pivot helper to ensure non-empty, sorted output for multiple tickers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79d933b288333a338d1d566e87267