### PR TITLE
Avoid redundant smile recomputes

### DIFF
--- a/display/gui/gui_plot_manager.py
+++ b/display/gui/gui_plot_manager.py
@@ -254,8 +254,6 @@ class PlotManager:
                 "target": target,
                 "asof": pd.to_datetime(asof).floor("min").isoformat(),
                 "T_days": float(T_days),
-                "model": model,
-                "ci": ci,
                 "overlay_synth": overlay_synth,
                 "peers": sorted(peers),
                 "weights": weights.to_dict() if weights is not None else None,
@@ -867,13 +865,16 @@ class PlotManager:
         fit_map = self._smile_ctx.get("fit_by_expiry", {})
         pre = fit_map.get(T0)
         pre_params = pre.get(model) if isinstance(pre, dict) else None
-        if not pre_params:
+        if pre_params is None:
             if model == "svi":
                 pre_params = fit_svi_slice(S, K, T0, IV)
             elif model == "sabr":
                 pre_params = fit_sabr_slice(S, K, T0, IV)
             else:
                 pre_params = fit_tps_slice(S, K, T0, IV)
+            if isinstance(pre, dict):
+                pre[model] = pre_params
+                fit_map[T0] = pre
         bands = None
         if ci and ci > 0:
             m_grid = np.linspace(0.7, 1.3, 121)

--- a/tests/test_smile_no_recompute.py
+++ b/tests/test_smile_no_recompute.py
@@ -1,0 +1,67 @@
+import json
+import numpy as np
+import matplotlib.pyplot as plt
+from display.gui.gui_plot_manager import PlotManager
+
+
+def test_smile_no_recompute_on_model_switch(monkeypatch):
+    """Changing only the model should reuse cached smile data."""
+    pm = PlotManager()
+    fig, ax = plt.subplots()
+
+    calls = {"n": 0}
+    cache: dict[str, object] = {}
+
+    def fake_compute_or_load(name, payload, builder):
+        key = json.dumps(payload, sort_keys=True)
+        if key not in cache:
+            cache[key] = builder()
+            calls["n"] += 1
+        return cache[key]
+
+    monkeypatch.setattr("display.gui.gui_plot_manager.compute_or_load", fake_compute_or_load)
+
+    def fake_prepare_smile_data(**kwargs):
+        return {
+            "T_arr": np.array([0.1]),
+            "K_arr": np.array([1.0]),
+            "sigma_arr": np.array([0.2]),
+            "S_arr": np.array([1.0]),
+            "Ts": np.array([0.1]),
+            "idx0": 0,
+            "tgt_surface": None,
+            "syn_surface": None,
+            "peer_slices": {},
+            "expiry_arr": np.array([0.1]),
+            "fit_by_expiry": {0.1: {"svi": {"a": 1}, "sabr": {"alpha": 1}, "tps": {}, "sens": {}}},
+        }
+
+    monkeypatch.setattr(
+        "display.gui.gui_plot_manager.prepare_smile_data", fake_prepare_smile_data
+    )
+
+    monkeypatch.setattr(PlotManager, "_render_smile_at_index", lambda self: None)
+
+    settings = {
+        "plot_type": "Smile",
+        "target": "T",
+        "asof": "2024-01-01",
+        "model": "svi",
+        "T_days": 30,
+        "ci": 68.0,
+        "x_units": "mny",
+        "atm_band": 0.05,
+        "weight_method": "corr",
+        "feature_mode": "iv_atm",
+        "overlay_synth": False,
+        "overlay_peers": False,
+        "peers": [],
+        "pillars": [],
+        "max_expiries": 6,
+    }
+
+    pm.plot(ax, settings)
+    settings["model"] = "sabr"
+    pm.plot(ax, settings)
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- Skip encoding model and confidence interval in smile cache keys so cached data survives GUI model changes
- Preserve precomputed smile fits and store on first compute to prevent re-fitting
- Add regression test ensuring model switches reuse cached smile data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a063b60c83339f16ef30e7661975