### PR TITLE
refactor: drop legacy weight mode paths

### DIFF
--- a/analysis/analysis_synthetic_etf.py
+++ b/analysis/analysis_synthetic_etf.py
@@ -23,7 +23,7 @@ NOTE: For call/put separated surfaces you would extend build_surface_grids
 
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Iterable, Dict, Optional, Tuple, Literal
+from typing import Iterable, Dict, Optional, Tuple
 import pandas as pd
 import numpy as np
 import os
@@ -45,7 +45,7 @@ from analysis.unified_weights import UnifiedWeightComputer, WeightConfig, Featur
 from analysis.pillars import compute_atm_by_expiry
 from analysis.syntheticETFBuilder import build_synthetic_iv_by_rank
 
-WeightMode = Literal["corr", "pca", "cosine", "equal", "custom"]
+WeightMode = str
 
 
 @dataclass
@@ -57,7 +57,7 @@ class SyntheticETFConfig:
     mny_bins: Tuple[Tuple[float, float], ...] = DEFAULT_MNY_BINS
     tolerance_days: float = 7.0
     lookback: int = 60
-    weight_mode: WeightMode = "corr"
+    weight_mode: WeightMode = "corr_iv_atm"
     weight_power: float = 1.0
     clip_negative: bool = True
     use_atm_only_surface: bool = False
@@ -111,7 +111,7 @@ class SyntheticETFBuilder:
             w = pd.Series(custom_weights, dtype=float)
             return w / w.sum()
 
-        cfg = WeightConfig.from_legacy_mode(
+        cfg = WeightConfig.from_mode(
             self.cfg.weight_mode,
             tenors=self.cfg.tenors,
             mny_bins=self.cfg.mny_bins,
@@ -304,7 +304,7 @@ class SyntheticETFBuilder:
 def build_synthetic_etf(
     target: str,
     peers: Iterable[str],
-    weight_mode: WeightMode = "corr",
+    weight_mode: WeightMode = "corr_iv_atm",
     custom_weights: Optional[Dict[str, float]] = None,
     **kwargs,
 ) -> SyntheticETFArtifacts:

--- a/analysis/beta_builder.py
+++ b/analysis/beta_builder.py
@@ -275,29 +275,6 @@ def iv_atm_betas(benchmark: str, pillar_days: Iterable[int] = DEFAULT_PILLARS_DA
     return out
 
 
-def iv_atm_betas_legacy(benchmark: str, pillar_days: Iterable[int] = DEFAULT_PILLARS_DAYS) -> Dict[int, pd.Series]:
-    """Legacy pillar-based IV ATM betas computation (kept for reference)."""
-    atm = load_atm()
-    if atm.empty:
-        return {}
-    piv = nearest_pillars(atm, pillars_days=pillar_days)
-    out: Dict[int, pd.Series] = {}
-    for d in sorted(set(piv["pillar_days"])):
-        sub = piv[piv["pillar_days"] == d]
-        wide = sub.pivot_table(index="asof_date", columns="ticker", values="iv", aggfunc="mean").sort_index()
-        wide = wide.sub(wide.mean(axis=1), axis=0)  # de-mean per day
-        bench = benchmark.upper()
-        if bench not in wide.columns:
-            continue
-        betas = {}
-        for t in wide.columns:
-            if t == bench:
-                continue
-            betas[t] = _beta(wide.rename(columns={t: "x", bench: "b"}), "x", "b")
-        out[int(d)] = pd.Series(betas, name=f"iv_atm_beta_{int(d)}d")
-    return out
-
-
 def surface_betas(
     benchmark: str,
     tenors: Iterable[int] = (7, 30, 60, 90, 180, 365),

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -25,7 +25,7 @@ def test_auto_update():
     
     print(f"\n3. Testing 'ul' weight mode with auto-update...")
     try:
-        config = WeightConfig.from_legacy_mode("ul")
+        config = WeightConfig.from_mode("corr_ul")
         computer = UnifiedWeightComputer()
         
         # This should trigger auto-update in underlying_returns_matrix

--- a/tests/test_ul_direct.py
+++ b/tests/test_ul_direct.py
@@ -7,8 +7,7 @@ from analysis.unified_weights import UnifiedWeightComputer, WeightConfig
 
 def test_ul_weight_mode():
     """Test that ul weight mode works correctly."""
-    # Test legacy mode conversion
-    config = WeightConfig.from_legacy_mode("ul")
+    config = WeightConfig.from_mode("corr_ul")
     
     # Test with real data
     computer = UnifiedWeightComputer()

--- a/tests/test_ul_mode.py
+++ b/tests/test_ul_mode.py
@@ -4,10 +4,10 @@
 from analysis.unified_weights import WeightConfig
 
 def test_ul_mode_conversion():
-    """Test the from_legacy_mode conversion for 'ul'."""
-    print("Testing 'ul' mode conversion...")
-    
-    config = WeightConfig.from_legacy_mode("ul")
+    """Test the canonical 'corr_ul' mode conversion."""
+    print("Testing 'corr_ul' mode conversion...")
+
+    config = WeightConfig.from_mode("corr_ul")
     print(f"Method: {config.method}")
     print(f"Feature set: {config.feature_set}")
     print(f"Expected: CORRELATION method with UNDERLYING_PX features")
@@ -19,7 +19,7 @@ def test_ul_mode_conversion():
     cfg = SyntheticETFConfig(
         target="SPY",
         peers=("QQQ", "IWM"),
-        weight_mode="ul"
+        weight_mode="corr_ul"
     )
     
     builder = SyntheticETFBuilder(cfg)

--- a/tests/test_ul_weights.py
+++ b/tests/test_ul_weights.py
@@ -34,7 +34,7 @@ def test_ul_weight_mode_uses_correlation(monkeypatch):
     monkeypatch.setattr("data.db_utils.get_conn", lambda db_path=None: conn)
 
     weights = compute_unified_weights(
-        target="TGT", peers=["AAA", "BBB"], mode="ul", asof="2024-01-04"
+        target="TGT", peers=["AAA", "BBB"], mode="corr_ul", asof="2024-01-04"
     )
 
     df = pd.DataFrame(

--- a/tests/test_weight_mode_recalc.py
+++ b/tests/test_weight_mode_recalc.py
@@ -12,7 +12,7 @@ def test_weights_recomputed_on_weight_mode_change(monkeypatch):
         index=["PEER", "TARGET"],
         columns=["PEER", "TARGET"],
     )
-    pm.last_corr_meta = {"weight_mode": "iv_atm"}
+    pm.last_corr_meta = {"weight_mode": "corr_iv_atm"}
 
     calls = {"compute": 0}
 
@@ -26,7 +26,7 @@ def test_weights_recomputed_on_weight_mode_change(monkeypatch):
         "analysis.unified_weights.compute_unified_weights", fake_compute_unified_weights
     )
 
-    pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "iv_atm")
-    pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "ul")
+    pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "corr_iv_atm")
+    pm._weights_from_ui_or_matrix("TARGET", ["PEER"], "corr_ul")
 
     assert calls["compute"] == 2


### PR DESCRIPTION
## Summary
- remove legacy weight_mode parsing and wrappers
- simplify peer weight routing to unified API
- update synthetic ETF configuration and tests to canonical modes

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after tests finish, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a87777da4c8333b9fc275035542cad