### PR TITLE
Refactor analysis helpers into dedicated modules

### DIFF
--- a/analysis/analysis_pipeline.py
+++ b/analysis/analysis_pipeline.py
@@ -39,6 +39,11 @@ from .syntheticETFBuilder import (
     combine_surfaces,
     build_synthetic_iv as build_synthetic_iv_pillars,
 )
+from .synthetic import build_synthetic_iv_series
+from .relative_value import (
+    relative_value_atm_report_corrweighted,
+    latest_relative_snapshot_corrweighted,
+)
 
 from .beta_builder.beta_builder import (
     pca_weights,
@@ -203,15 +208,6 @@ def build_synthetic_surface(
     surfaces = build_surfaces(tickers=list(w.keys()), cfg=cfg, most_recent_only=most_recent_only)
     return combine_surfaces(surfaces, w)
 
-
-def build_synthetic_iv_series(
-    weights: Mapping[str, float],
-    pillar_days: Union[int, Iterable[int]] = DEFAULT_PILLARS_DAYS,
-    tolerance_days: float = 7.0,
-) -> pd.DataFrame:
-    """Create a weighted ATM pillar IV time series."""
-    w = {k.upper(): float(v) for k, v in weights.items()}
-    return build_synthetic_iv_pillars(w, pillar_days=pillar_days, tolerance_days=tolerance_days)
 
 # -----------------------------------------------------------------------------
 # Weights (modern unified first, legacy fallback kept)
@@ -455,120 +451,7 @@ def save_betas(
         return [p]
     return save_correlations(mode=mode, benchmark=benchmark, base_path=base_path)
 # =========================
-# Relative value (target vs synthetic peers by corr)
-# -----------------------------------------------------------------------------
-def _fetch_target_atm(
-    target: str,
-    pillar_days: Iterable[int],
-    tolerance_days: float = 7.0
-) -> pd.DataFrame:
-    atm = load_atm()
-    atm = atm[atm["ticker"] == target].copy()
-    if atm.empty:
-        return pd.DataFrame(columns=["asof_date", "pillar_days", "iv"])
-    piv = nearest_pillars(atm, pillars_days=list(pillar_days), tolerance_days=tolerance_days)
-    out = piv.groupby(["asof_date", "pillar_days"])["iv"].mean().rename("iv").reset_index()
-    return out[["asof_date", "pillar_days", "iv"]]
-
-
-def _rv_metrics_join(target_iv: pd.DataFrame, synth_iv: pd.DataFrame, lookback: int = 60) -> pd.DataFrame:
-    tgt = target_iv.rename(columns={"iv": "iv_target"})
-    syn = synth_iv.rename(columns={"iv": "iv_synth"})
-    df = pd.merge(tgt, syn, on=["asof_date", "pillar_days"], how="inner").sort_values(["pillar_days", "asof_date"])
-    if df.empty:
-        return df
-
-    def per_pillar(g: pd.DataFrame) -> pd.DataFrame:
-        g = g.copy()
-        g["spread"] = g["iv_target"] - g["iv_synth"]
-        roll = max(5, int(lookback // 5))
-        m = g["spread"].rolling(lookback, min_periods=roll).mean()
-        s = g["spread"].rolling(lookback, min_periods=roll).std(ddof=1)
-        g["z"] = (g["spread"] - m) / s
-        # percentile rank of latest value within window
-        def _pct_rank(x: pd.Series) -> float:
-            return x.rank(pct=True).iloc[-1]
-        g["pct_rank"] = g["spread"].rolling(lookback, min_periods=roll).apply(_pct_rank, raw=False)
-        return g
-
-    return df.groupby("pillar_days", group_keys=False).apply(per_pillar, include_groups=False)
-
-
-def relative_value_atm_report_corrweighted(
-    target: str,
-    peers: Iterable[str] | None = None,
-    mode: str = "iv_atm",                # 'ul' | 'iv_atm' | 'surface'  (weights source)
-    pillar_days: Iterable[int] = DEFAULT_PILLARS_DAYS,
-    lookback: int = 60,
-    tolerance_days: float = 7.0,
-    weight_power: float = 1.0,
-    clip_negative: bool = True,
-) -> tuple[pd.DataFrame, pd.Series]:
-    """
-    Compute relative value (spread/z/pct) using correlation-based peer weights.
-    Returns (rv_dataframe, weights_used).
-    """
-    w = peer_weights_from_correlations(
-        benchmark=target,
-        peers=peers,
-        mode=mode,
-        pillar_days=pillar_days,
-        tenor_days=DEFAULT_TENORS,
-        mny_bins=DEFAULT_MNY_BINS,
-        clip_negative=clip_negative,
-        power=weight_power,
-    )
-    if w.empty:
-        empty_cols = ["asof_date", "pillar_days", "iv_target", "iv_synth", "spread", "z", "pct_rank"]
-        return pd.DataFrame(columns=empty_cols), w
-
-    synth = build_synthetic_iv_series(weights=w.to_dict(), pillar_days=pillar_days, tolerance_days=tolerance_days)
-    tgt = _fetch_target_atm(target, pillar_days=pillar_days, tolerance_days=tolerance_days)
-    rv = _rv_metrics_join(tgt, synth, lookback=lookback)
-    return rv, w
-
-
-def latest_relative_snapshot_corrweighted(
-    target: str,
-    peers: Iterable[str] | None = None,
-    mode: str = "iv_atm",
-    pillar_days: Iterable[int] = (7, 30, 60, 90),
-    lookback: int = 60,
-    tolerance_days: float = 7.0,
-    **kwargs,
-) -> tuple[pd.DataFrame, pd.Series]:
-    """
-    Convenience: last date per pillar with RV metrics and the weights used.
-    """
-    rv, w = relative_value_atm_report_corrweighted(
-        target=target, peers=peers, mode=mode, pillar_days=pillar_days,
-        lookback=lookback, tolerance_days=tolerance_days, **kwargs
-    )
-    # If nothing came back, just return early
-    if rv.empty:
-        return rv, w
-
-    # Ensure required columns exist even if upstream fallback omitted them
-    # - pillar_days: create a placeholder if missing (single bucket)
-    # - asof_date: ensure it exists and is sortable
-    if "pillar_days" not in rv.columns:
-        # treat whole snapshot as a single synthetic pillar bucket (e.g., 0)
-        rv = rv.copy()
-        rv["pillar_days"] = 0
-    if "asof_date" not in rv.columns:
-        # cannot manufacture real dates; create a constant so sort/group don't explode
-        rv = rv.copy()
-        rv["asof_date"] = pd.Timestamp("1970-01-01")
-
-    # Keep only columns we know how to present; tolerate missing metric columns
-    base_cols = ["asof_date", "pillar_days", "iv_target", "iv_synth", "spread", "z", "pct_rank"]
-    present_cols = [c for c in base_cols if c in rv.columns]
-
-    # Group safely by pillar and take the latest per pillar
-    last = rv.sort_values("asof_date").groupby("pillar_days", dropna=False).tail(1)
-    # Guarantee pillar_days in the projected set
-    proj_cols = sorted(set(["pillar_days", "asof_date"] + present_cols))
-    return last[proj_cols].sort_values("pillar_days"), w
+# Relative value helpers reside in ``analysis.relative_value``
 
 # -----------------------------------------------------------------------------
 # Basic DB helpers + caches

--- a/analysis/beta_builder/beta_builder.py
+++ b/analysis/beta_builder/beta_builder.py
@@ -8,8 +8,6 @@ import pandas as pd
 
 # Centralized builders & utilities
 from .unified_weights import (
-    atm_feature_matrix as uw_atm_feature_matrix,
-    surface_feature_matrix as uw_surface_feature_matrix,
     underlying_returns_matrix as uw_underlying_returns_matrix,
 )
 from .cosine import cosine_similarity_weights_from_matrix as uw_cosine_from_matrix
@@ -18,66 +16,15 @@ from .pca import (
     pca_regress_weights as uw_pca_regress_weights,
     pca_market_weights as uw_pca_market_weights,
 )
-from .utils import impute_col_median as _impute_col_median
+from .utils import (
+    impute_col_median as _impute_col_median,
+    safe_var as _safe_var,
+    beta as _beta,
+)
+from .feature_matrices import atm_feature_matrix, surface_feature_matrix
 
 from analysis.pillars import DEFAULT_PILLARS_DAYS
 
-
-
-# =========================
-# Small numeric helpers (lightweight; kept local)
-# =========================
-def _safe_var(x: pd.Series) -> float:
-    v = x.var()
-    return float(v) if (v is not None and np.isfinite(v) and v > 0) else float("nan")
-
-
-def _beta(df: pd.DataFrame, x: str, b: str) -> float:
-    a = df[[x, b]].dropna()
-    if len(a) < 5:
-        return float("nan")
-    vb = _safe_var(a[b])
-    return float(a[x].cov(a[b]) / vb) if np.isfinite(vb) else float("nan")
-
-
-# =========================
-# Centralized feature matrix shims
-# =========================
-def atm_feature_matrix(
-    get_smile_slice,
-    tickers: Iterable[str],
-    asof: str,
-    pillars_days: Iterable[int],
-    atm_band: float = 0.08,
-    tol_days: float = 10.0,
-    standardize: bool = True,
-) -> Tuple[pd.DataFrame, np.ndarray, List[str]]:
-    """Rows=tickers, cols=pillars. Delegates to unified_weights."""
-    return uw_atm_feature_matrix(
-        tickers=[t.upper() for t in tickers],
-        asof=asof,
-        pillars_days=pillars_days,
-        atm_band=atm_band,
-        tol_days=tol_days,
-        standardize=standardize,
-    )
-
-
-def surface_feature_matrix(
-    tickers: Iterable[str],
-    asof: str,
-    tenors: Iterable[int] | None = None,
-    mny_bins: Iterable[Tuple[float, float]] | None = None,
-    standardize: bool = True,
-) -> Tuple[Dict[str, Dict[pd.Timestamp, pd.DataFrame]], np.ndarray, List[str]]:
-    """Rows=tickers, cols=flattened (tenor × moneyness). Delegates to unified_weights."""
-    return uw_surface_feature_matrix(
-        tickers=[t.upper() for t in tickers],
-        asof=asof,
-        tenors=tenors,
-        mny_bins=mny_bins,
-        standardize=standardize,
-    )
 
 
 # =========================

--- a/analysis/beta_builder/correlation.py
+++ b/analysis/beta_builder/correlation.py
@@ -10,7 +10,7 @@ def corr_weights_from_matrix(
     clip_negative: bool = True,
     power: float = 1.0,
 ) -> pd.Series:
-    """Compute correlation‑based weights from a ticker×feature matrix."""
+    """Compute correlation-based weights from a ticker×feature matrix."""
     target = target.upper()
     peers = [p.upper() for p in peers]
     corr_df = feature_df.T.corr()
@@ -24,62 +24,3 @@ def corr_weights_from_matrix(
     if not np.isfinite(total) or total <= 0:
         raise ValueError("correlation weights sum to zero")
     return (s / total).reindex(peers).fillna(0.0)
-
-def_corr_execution(
-        # New unified-style helpers for corr paths (ATM/Surface matrix)
-            # Corr-based quick paths
-    if feature in ("iv_atm", "surface", "ul") and method == "corr":
-        return peer_weights_from_correlations(
-            benchmark=target,
-            peers=peers,
-            mode=feature if feature != "ul" else "ul",
-            pillar_days=pillar_days,
-            tenor_days=tenor_days,
-            mny_bins=mny_bins,
-            clip_negative=True,
-            power=1.0,
-        )
-
-    if feature == "atm" and method == "corr":
-        if asof is None:
-            dates = available_dates(ticker=target, most_recent_only=True)
-            asof = dates[0] if dates else None
-        if asof is None:
-            return pd.Series(dtype=float)
-        atm_df, corr_df = compute_atm_corr_pillar_free(
-            get_smile_slice=get_smile_slice,
-            tickers=[target] + peers,
-            asof=asof,
-            max_expiries=6,
-            atm_band=0.05,
-        )
-        return corr_weights(corr_df, target, peers)
-    if feature == "surface" and method == "corr":
-        if asof is None:
-            dates = available_dates(ticker=target, most_recent_only=True)
-            asof = dates[0] if dates else None
-        if asof is None:
-            return pd.Series(dtype=float)
-        corr_df = compute_atm_corr_pillar_free(
-            get_smile_slice=get_smile_slice,
-            tickers=[target] + list(peers),
-            asof=asof,
-            max_expiries=6,
-            atm_band=0.05,
-        )[1]
-        return corr_weights_from_matrix(corr_df, target, peers)
-    if feature == "ul" and method == "corr":
-        if asof is None:
-            dates = available_dates(ticker=target, most_recent_only=True)
-            asof = dates[0] if dates else None
-        if asof is None:
-            return pd.Series(dtype=float)
-        corr_df = compute_atm_corr_pillar_free(
-            get_smile_slice=get_smile_slice,
-            tickers=[target] + list(peers),
-            asof=asof,
-            max_expiries=6,
-            atm_band=0.05,
-        )[1]
-        return corr_weights_from_matrix(corr_df, target, peers)
-)

--- a/analysis/beta_builder/feature_matrices.py
+++ b/analysis/beta_builder/feature_matrices.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import Iterable, Tuple, Dict, List
+
+import numpy as np
+import pandas as pd
+
+from .unified_weights import (
+    atm_feature_matrix as uw_atm_feature_matrix,
+    surface_feature_matrix as uw_surface_feature_matrix,
+)
+
+
+def atm_feature_matrix(
+    get_smile_slice,
+    tickers: Iterable[str],
+    asof: str,
+    pillars_days: Iterable[int],
+    atm_band: float = 0.08,
+    tol_days: float = 10.0,
+    standardize: bool = True,
+) -> Tuple[pd.DataFrame, np.ndarray, List[str]]:
+    """Wrapper around unified weights ATM builder."""
+    return uw_atm_feature_matrix(
+        tickers=[t.upper() for t in tickers],
+        asof=asof,
+        pillars_days=pillars_days,
+        atm_band=atm_band,
+        tol_days=tol_days,
+        standardize=standardize,
+    )
+
+
+def surface_feature_matrix(
+    tickers: Iterable[str],
+    asof: str,
+    tenors: Iterable[int] | None = None,
+    mny_bins: Iterable[Tuple[float, float]] | None = None,
+    standardize: bool = True,
+) -> Tuple[Dict[str, Dict[pd.Timestamp, pd.DataFrame]], np.ndarray, List[str]]:
+    """Wrapper around unified weights surface builder."""
+    return uw_surface_feature_matrix(
+        tickers=[t.upper() for t in tickers],
+        asof=asof,
+        tenors=tenors,
+        mny_bins=mny_bins,
+        standardize=standardize,
+    )

--- a/analysis/beta_builder/utils.py
+++ b/analysis/beta_builder/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 
 def impute_col_median(X: np.ndarray) -> np.ndarray:
@@ -17,3 +18,18 @@ def zscore_cols(X: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     sd = np.nanstd(X, axis=0, ddof=1, keepdims=True)
     sd = np.where(~np.isfinite(sd) | (sd <= 0), 1.0, sd)
     return (X - mu) / sd, mu, sd
+
+
+def safe_var(x: pd.Series) -> float:
+    """Finite variance or ``nan`` if unavailable/degenerate."""
+    v = x.var()
+    return float(v) if (v is not None and np.isfinite(v) and v > 0) else float("nan")
+
+
+def beta(df: pd.DataFrame, x: str, b: str) -> float:
+    """Simple ``beta`` of column ``x`` versus benchmark column ``b``."""
+    a = df[[x, b]].dropna()
+    if len(a) < 5:
+        return float("nan")
+    vb = safe_var(a[b])
+    return float(a[x].cov(a[b]) / vb) if np.isfinite(vb) else float("nan")

--- a/analysis/relative_value.py
+++ b/analysis/relative_value.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+from typing import Iterable, Tuple
+
+import pandas as pd
+
+from .pillars import load_atm, nearest_pillars, DEFAULT_PILLARS_DAYS
+from .synthetic import build_synthetic_iv_series
+from .beta_builder.beta_builder import peer_weights_from_correlations
+from .syntheticETFBuilder import DEFAULT_TENORS, DEFAULT_MNY_BINS
+
+
+def _fetch_target_atm(
+    target: str,
+    pillar_days: Iterable[int],
+    tolerance_days: float = 7.0,
+) -> pd.DataFrame:
+    atm = load_atm()
+    atm = atm[atm["ticker"] == target].copy()
+    if atm.empty:
+        return pd.DataFrame(columns=["asof_date", "pillar_days", "iv"])
+    piv = nearest_pillars(atm, pillars_days=list(pillar_days), tolerance_days=tolerance_days)
+    out = piv.groupby(["asof_date", "pillar_days"])["iv"].mean().rename("iv").reset_index()
+    return out[["asof_date", "pillar_days", "iv"]]
+
+
+def _rv_metrics_join(target_iv: pd.DataFrame, synth_iv: pd.DataFrame, lookback: int = 60) -> pd.DataFrame:
+    tgt = target_iv.rename(columns={"iv": "iv_target"})
+    syn = synth_iv.rename(columns={"iv": "iv_synth"})
+    df = pd.merge(tgt, syn, on=["asof_date", "pillar_days"], how="inner").sort_values(["pillar_days", "asof_date"])
+    if df.empty:
+        return df
+
+    def per_pillar(g: pd.DataFrame) -> pd.DataFrame:
+        g = g.copy()
+        g["spread"] = g["iv_target"] - g["iv_synth"]
+        roll = max(5, int(lookback // 5))
+        m = g["spread"].rolling(lookback, min_periods=roll).mean()
+        s = g["spread"].rolling(lookback, min_periods=roll).std(ddof=1)
+        g["z"] = (g["spread"] - m) / s
+        # percentile rank of latest value within window
+        def _pct_rank(x: pd.Series) -> float:
+            return x.rank(pct=True).iloc[-1]
+        g["pct_rank"] = g["spread"].rolling(lookback, min_periods=roll).apply(_pct_rank, raw=False)
+        return g
+
+    return df.groupby("pillar_days", group_keys=False).apply(per_pillar, include_groups=False)
+
+
+def relative_value_atm_report_corrweighted(
+    target: str,
+    peers: Iterable[str] | None = None,
+    mode: str = "iv_atm",
+    pillar_days: Iterable[int] = DEFAULT_PILLARS_DAYS,
+    lookback: int = 60,
+    tolerance_days: float = 7.0,
+    weight_power: float = 1.0,
+    clip_negative: bool = True,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """Compute relative value using correlation-based peer weights."""
+    w = peer_weights_from_correlations(
+        benchmark=target,
+        peers=peers,
+        mode=mode,
+        pillar_days=pillar_days,
+        tenor_days=DEFAULT_TENORS,
+        mny_bins=DEFAULT_MNY_BINS,
+        clip_negative=clip_negative,
+        power=weight_power,
+    )
+    if w.empty:
+        empty_cols = ["asof_date", "pillar_days", "iv_target", "iv_synth", "spread", "z", "pct_rank"]
+        return pd.DataFrame(columns=empty_cols), w
+
+    synth = build_synthetic_iv_series(weights=w.to_dict(), pillar_days=pillar_days, tolerance_days=tolerance_days)
+    tgt = _fetch_target_atm(target, pillar_days=pillar_days, tolerance_days=tolerance_days)
+    rv = _rv_metrics_join(tgt, synth, lookback=lookback)
+    return rv, w
+
+
+def latest_relative_snapshot_corrweighted(
+    target: str,
+    peers: Iterable[str] | None = None,
+    mode: str = "iv_atm",
+    pillar_days: Iterable[int] = (7, 30, 60, 90),
+    lookback: int = 60,
+    tolerance_days: float = 7.0,
+    **kwargs,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """Convenience wrapper returning the latest date per pillar with RV metrics."""
+    rv, w = relative_value_atm_report_corrweighted(
+        target=target,
+        peers=peers,
+        mode=mode,
+        pillar_days=pillar_days,
+        lookback=lookback,
+        tolerance_days=tolerance_days,
+        **kwargs,
+    )
+    if rv.empty:
+        return rv, w
+
+    if "pillar_days" not in rv.columns:
+        rv = rv.copy()
+        rv["pillar_days"] = 0
+    if "asof_date" not in rv.columns:
+        rv = rv.copy()
+        rv["asof_date"] = pd.Timestamp("1970-01-01")
+
+    out_rows = []
+    for pdays, g in rv.groupby("pillar_days"):
+        out_rows.append(g.sort_values("asof_date").iloc[-1])
+    out = pd.DataFrame(out_rows).reset_index(drop=True)
+    out = out.sort_values("pillar_days").reset_index(drop=True)
+    return out, w

--- a/analysis/synthetic.py
+++ b/analysis/synthetic.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Mapping, Iterable, Union
+
+import pandas as pd
+
+from .pillars import DEFAULT_PILLARS_DAYS
+from .syntheticETFBuilder import build_synthetic_iv as build_synthetic_iv_pillars
+
+
+def build_synthetic_iv_series(
+    weights: Mapping[str, float],
+    pillar_days: Union[int, Iterable[int]] = DEFAULT_PILLARS_DAYS,
+    tolerance_days: float = 7.0,
+) -> pd.DataFrame:
+    """Create a weighted ATM pillar IV time series."""
+    w = {k.upper(): float(v) for k, v in weights.items()}
+    return build_synthetic_iv_pillars(w, pillar_days=pillar_days, tolerance_days=tolerance_days)

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -10,7 +10,7 @@ from .ticker_groups import (
     delete_ticker_group, create_default_groups
 )
 from .db_utils import get_conn, ensure_initialized, ensure_indexes, insert_features
-from .historical_saver import save_for_tickers
+from .data_downloader import save_for_tickers
 from .underlying_prices import update_underlying_prices
 from .interest_rates import (
     save_interest_rate, load_interest_rate, get_default_interest_rate,

--- a/data/data_downloader.py
+++ b/data/data_downloader.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from typing import Iterable
 
 from .db_utils import get_conn, ensure_initialized, insert_quotes, insert_features
-from .data_downloader import download_raw_option_data
 from .data_pipeline import enrich_quotes
 from .interest_rates import STANDARD_RISK_FREE_RATE, STANDARD_DIVIDEND_YIELD
 from .feature_engineering import add_all_features


### PR DESCRIPTION
## Summary
- Move numerical helpers from `beta_builder` to `utils` and create dedicated `feature_matrices` module
- Extract synthetic IV builder and relative-value analytics into new modules and slim `analysis_pipeline`
- Fix data package imports and clean up downloader implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87c92b18c8333bb46c9796e85a7ac